### PR TITLE
Refactor/send inactive instead of backgrounded

### DIFF
--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -994,7 +994,7 @@ BOOL inForeground = NO;
 
     // Pause.
     [[NSNotificationCenter defaultCenter]
-        addObserverForName:UIApplicationDidEnterBackgroundNotification
+        addObserverForName:UIApplicationWillResignActiveNotification
                     object:nil
                      queue:nil
                 usingBlock:^(NSNotification *notification) {
@@ -1009,7 +1009,7 @@ BOOL inForeground = NO;
 
     // Resume.
     [[NSNotificationCenter defaultCenter]
-        addObserverForName:UIApplicationWillEnterForegroundNotification
+        addObserverForName:UIApplicationDidBecomeActiveNotification
                     object:nil
                      queue:nil
                 usingBlock:^(NSNotification *notification) {


### PR DESCRIPTION
Currently we send the pause state when the app is backgrounded. This does not give enough time to send requests when the app is force quited. We will have more time to send by sending it when the app is inactive instead.