### PR TITLE
Fix/remove getlastresponse/lp 4868

### DIFF
--- a/Leanplum-SDK/Classes/LPActionManager.m
+++ b/Leanplum-SDK/Classes/LPActionManager.m
@@ -363,15 +363,14 @@ static dispatch_once_t leanplum_onceToken;
                                              LP_PARAM_INCLUDE_DEFAULTS: @(NO),
                                              LP_PARAM_INCLUDE_MESSAGE_ID: messageId
                                              }];
-            [req onResponse:^(id<LPNetworkOperationProtocol> operation, id json) {
+            [req onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
                 LP_TRY
-                NSDictionary *getVariablesResponse = [LPResponse getLastResponse:json];
-                NSDictionary *values = getVariablesResponse[LP_KEY_VARS];
-                NSDictionary *messages = getVariablesResponse[LP_KEY_MESSAGES];
-                NSArray *updateRules = getVariablesResponse[LP_KEY_UPDATE_RULES];
-                NSArray *eventRules = getVariablesResponse[LP_KEY_EVENT_RULES];
-                NSArray *variants = getVariablesResponse[LP_KEY_VARIANTS];
-                NSDictionary *regions = getVariablesResponse[LP_KEY_REGIONS];
+                NSDictionary *values = response[LP_KEY_VARS];
+                NSDictionary *messages = response[LP_KEY_MESSAGES];
+                NSArray *updateRules = response[LP_KEY_UPDATE_RULES];
+                NSArray *eventRules = response[LP_KEY_EVENT_RULES];
+                NSArray *variants = response[LP_KEY_VARIANTS];
+                NSDictionary *regions = response[LP_KEY_REGIONS];
                 if (![LPConstantsState sharedState].canDownloadContentMidSessionInProduction ||
                     [values isEqualToDictionary:LPVarCache.diffs]) {
                     values = nil;

--- a/Leanplum-SDK/Classes/LPInbox.m
+++ b/Leanplum-SDK/Classes/LPInbox.m
@@ -409,9 +409,8 @@ static NSObject *updatingLock;
     RETURN_IF_NOOP;
     LP_TRY
     LeanplumRequest *req = [LeanplumRequest post:LP_METHOD_GET_INBOX_MESSAGES params:nil];
-    [req onResponse:^(id<LPNetworkOperationProtocol> operation, id json) {
+    [req onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
         LP_TRY
-        NSDictionary *response = [LPResponse getLastResponse:json];
         NSDictionary *messagesDict = response[LP_KEY_INBOX_MESSAGES];
         NSUInteger unreadCount = 0;
         NSMutableDictionary *messages = [[NSMutableDictionary alloc] init];

--- a/Leanplum-SDK/Classes/LPRegisterDevice.m
+++ b/Leanplum-SDK/Classes/LPRegisterDevice.m
@@ -46,14 +46,13 @@
 {
     LeanplumRequest *request = [LeanplumRequest post:LP_METHOD_REGISTER_FOR_DEVELOPMENT
                                               params:@{ LP_PARAM_EMAIL: email }];
-    [request onResponse:^(id<LPNetworkOperationProtocol> operation, id json) {
+    [request onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
         LP_TRY
-        NSDictionary* registerResponse = [LPResponse getLastResponse:json];
-        BOOL isSuccess = [LPResponse isResponseSuccess:registerResponse];
+        BOOL isSuccess = [LPResponse isResponseSuccess:response];
         if (isSuccess) {
             self->callback(YES);
         } else {
-            [self showError:[LPResponse getResponseError:registerResponse]];
+            [self showError:[LPResponse getResponseError:response]];
         }
         LP_END_TRY
     }];

--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -881,11 +881,10 @@ BOOL inForeground = NO;
 
     // Issue start API call.
     LeanplumRequest *req = [LeanplumRequest post:LP_METHOD_START params:params];
-    [req onResponse:^(id<LPNetworkOperationProtocol> operation, id json) {
+    [req onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
         LP_TRY
         state.hasStarted = YES;
         state.startSuccessful = YES;
-        NSDictionary *response = [LPResponse getLastResponse:json];
         NSDictionary *values = response[LP_KEY_VARS];
         NSString *token = response[LP_KEY_TOKEN];
         NSDictionary *messages = response[LP_KEY_MESSAGES];
@@ -2182,15 +2181,14 @@ andParameters:(NSDictionary *)params
     LeanplumRequest* req = [LeanplumRequest
                             post:LP_METHOD_GET_VARS
                             params:params];
-    [req onResponse:^(id<LPNetworkOperationProtocol> operation, id json) {
+    [req onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
         LP_TRY
-        NSDictionary *getVariablesResponse = [LPResponse getLastResponse:json];
-        NSDictionary *values = getVariablesResponse[LP_KEY_VARS];
-        NSDictionary *messages = getVariablesResponse[LP_KEY_MESSAGES];
-        NSArray *updateRules = getVariablesResponse[LP_KEY_UPDATE_RULES];
-        NSArray *eventRules = getVariablesResponse[LP_KEY_EVENT_RULES];
-        NSArray *variants = getVariablesResponse[LP_KEY_VARIANTS];
-        NSDictionary *regions = getVariablesResponse[LP_KEY_REGIONS];
+        NSDictionary *values = response[LP_KEY_VARS];
+        NSDictionary *messages = response[LP_KEY_MESSAGES];
+        NSArray *updateRules = response[LP_KEY_UPDATE_RULES];
+        NSArray *eventRules = response[LP_KEY_EVENT_RULES];
+        NSArray *variants = response[LP_KEY_VARIANTS];
+        NSDictionary *regions = response[LP_KEY_REGIONS];
         if (![values isEqualToDictionary:LPVarCache.diffs] ||
             ![messages isEqualToDictionary:LPVarCache.messageDiffs] ||
             ![updateRules isEqualToArray:LPVarCache.updateRulesDiffs] ||
@@ -2204,7 +2202,7 @@ andParameters:(NSDictionary *)params
                                    regions:regions];
 
         }
-        if ([getVariablesResponse[LP_KEY_SYNC_INBOX] boolValue]) {
+        if ([response[LP_KEY_SYNC_INBOX] boolValue]) {
             [[self inbox] downloadMessages];
         }
         LP_END_TRY

--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -914,9 +914,6 @@ BOOL inForeground = NO;
         // [LPVarCache saveUserAttributes];
         [self triggerStartResponse:YES];
 
-        // Upload alternative app icons.
-        [LPAppIconManager uploadAppIconsOnDevMode];
-
         // Allow bidirectional realtime variable updates.
         if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
             // Register device.
@@ -966,6 +963,9 @@ BOOL inForeground = NO;
                                         }] send];
             }
         }
+
+        // Upload alternative app icons.
+        [LPAppIconManager uploadAppIconsOnDevMode];
 
         if (!startedInBackground) {
             inForeground = YES;

--- a/Leanplum-SDK/Classes/LeanplumRequest.h
+++ b/Leanplum-SDK/Classes/LeanplumRequest.h
@@ -34,6 +34,7 @@
     LPNetworkResponseBlock _response;
     LPNetworkErrorBlock _error;
     BOOL _sent;
+    NSInteger _eventIndex;
 }
 
 + (void)setAppId:(NSString *)appId withAccessKey:(NSString *)accessKey;

--- a/Leanplum-SDK/Classes/LeanplumRequest.m
+++ b/Leanplum-SDK/Classes/LeanplumRequest.m
@@ -768,6 +768,9 @@ static NSDictionary *_requestHheaders;
 
 /**
  * Static sendNowQueue with thread protection.
+ * Returns an operation queue that manages sendNow to run in order.
+ * This is required to prevent from having out of order error in the backend.
+ * Also it is very crucial with the uuid logic.
  */
 + (NSOperationQueue *)sendNowQueue
 {
@@ -782,6 +785,10 @@ static NSDictionary *_requestHheaders;
 
 /**
  * Static sendNowCallbackMap with thread protection.
+ * Returns dictionary that maps event index to response callback.
+ * Since requests are batched there can be a case where other LeanplumRequest
+ * can take future LeanplumRequest events. We need to ensure all callbacks are
+ * called from any instance.
  */
 + (NSMutableDictionary *)sendNowCallbackMap
 {

--- a/Leanplum-SDK/Classes/LeanplumRequest.m
+++ b/Leanplum-SDK/Classes/LeanplumRequest.m
@@ -745,7 +745,10 @@ static NSDictionary *_requestHheaders;
 
 + (NSDictionary *)getResponseAt:(NSUInteger)index fromDictionary:(NSDictionary *)dictionary
 {
-    return [dictionary[@"response"] objectAtIndex:index];
+    if (index < [LPResponse numResponsesInDictionary:dictionary]) {
+        return [dictionary[@"response"] objectAtIndex:index];
+    }
+    return [dictionary[@"response"] lastObject];
 }
 
 + (NSDictionary *)getLastResponse:(NSDictionary *)dictionary


### PR DESCRIPTION
There can be a corner case when the last response is not the response we are looking for. This is
highly unlikely because you need to have more than 10k events beforehand and need to have events
rights after you call start/forceContentUpdate, but this commit will fix it.