### PR TITLE
refactor(api): change to api.leanplum.com

### DIFF
--- a/Leanplum-SDK/Classes/Constants.h
+++ b/Leanplum-SDK/Classes/Constants.h
@@ -85,9 +85,10 @@
 
 @interface LPConstantsState : NSObject {
     NSString *_apiHostName;
+    NSString *_apiServlet;
+    BOOL _apiSSL;
     NSString *_socketHost;
     int _socketPort;
-    BOOL _apiSSL;
     int _networkTimeoutSeconds;
     int _networkTimeoutSecondsForDownloads;
     int _syncNetworkTimeoutSeconds;
@@ -95,7 +96,6 @@
     BOOL _isDevelopmentModeEnabled;
     BOOL _loggingEnabled;
     BOOL _canDownloadContentMidSessionInProduction;
-    NSString *_apiServlet;
     BOOL _isTestMode;
     BOOL _isInPermanentFailureState;
     BOOL _verboseLoggingInDevelopmentMode;

--- a/Leanplum-SDK/Classes/Constants.m
+++ b/Leanplum-SDK/Classes/Constants.m
@@ -42,10 +42,11 @@
 
 - (id)init {
     if (self = [super init]) {
-        _apiHostName = @"www.leanplum.com";
+        _apiHostName = @"api.leanplum.com";
+        _apiServlet = @"api";
+        _apiSSL = YES;
         _socketHost = @"dev.leanplum.com";
         _socketPort = 443;
-        _apiSSL = YES;
         _networkTimeoutSeconds = 10;
         _networkTimeoutSecondsForDownloads = 15;
         _syncNetworkTimeoutSeconds = 5;
@@ -53,7 +54,6 @@
         _isDevelopmentModeEnabled = NO;
         _loggingEnabled = NO;
         _canDownloadContentMidSessionInProduction = NO;
-        _apiServlet = @"api";
         _isTestMode = NO;
         _isInPermanentFailureState = NO;
         _verboseLoggingInDevelopmentMode = NO;

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -150,7 +150,7 @@ typedef enum {
 
 /**
  * Optional. Sets the API server. The API path is of the form http[s]://hostname/servletName
- * @param hostName The name of the API host, such as www.leanplum.com
+ * @param hostName The name of the API host, such as api.leanplum.com
  * @param servletName The name of the API servlet, such as api
  * @param ssl Whether to use SSL
  */


### PR DESCRIPTION
As discussed w/ infrastructure team, we will need to point to api.leanplum.com enabling them to migrate some services in the future independently.