### PR TITLE
fix(utils): Ruby string count check

### DIFF
--- a/Leanplum-SDK/Classes/Utils.m
+++ b/Leanplum-SDK/Classes/Utils.m
@@ -31,7 +31,8 @@
 {
     return obj == nil
         || ([obj respondsToSelector:@selector(length)] && [(NSData *)obj length] == 0)
-        || ([obj respondsToSelector:@selector(count)] && [(NSArray *)obj count] == 0);
+        || ([obj respondsToSelector:@selector(count)]
+            && ![obj isKindOfClass:[NSString class]] && [(NSArray *)obj count] == 0);
 }
 
 + (BOOL)isBlank:(NSString *)str

--- a/Leanplum-SDK/Classes/Utils.m
+++ b/Leanplum-SDK/Classes/Utils.m
@@ -30,8 +30,7 @@
 + (BOOL)isNullOrEmpty:(id)obj
 {
     // Need to check for NSString to support RubyMotion.
-    // Ruby String has count: method and respondsToSelector(count) is true for count:
-    // but count: in Ruby requires parameters
+    // Ruby String respondsToSelector(count) is true for count: in RubyMotion
     return obj == nil
     || ([obj respondsToSelector:@selector(length)] && [obj length] == 0)
     || ([obj respondsToSelector:@selector(count)]

--- a/Leanplum-SDK/Classes/Utils.m
+++ b/Leanplum-SDK/Classes/Utils.m
@@ -29,10 +29,13 @@
 
 + (BOOL)isNullOrEmpty:(id)obj
 {
+    // Need to check for NSString to support RubyMotion.
+    // Ruby String has count: method and respondsToSelector(count) is true for count:
+    // but count: in Ruby requires parameters
     return obj == nil
-        || ([obj respondsToSelector:@selector(length)] && [(NSData *)obj length] == 0)
-        || ([obj respondsToSelector:@selector(count)]
-            && ![obj isKindOfClass:[NSString class]] && [(NSArray *)obj count] == 0);
+    || ([obj respondsToSelector:@selector(length)] && [obj length] == 0)
+    || ([obj respondsToSelector:@selector(count)]
+        && ![obj isKindOfClass:[NSString class]] && [obj count] == 0);
 }
 
 + (BOOL)isBlank:(NSString *)str


### PR DESCRIPTION
This PR includes a change to enable using the SDK with Rubymotion:
- Condition to check for object count only if the object is not an NSString or subclass of NSString. The string size is checked in the length condition.
