### PR TITLE
Only send device name in development mode

### DIFF
--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -839,9 +839,10 @@ BOOL inForeground = NO;
     NSString *currentLocaleString = [NSString stringWithFormat:@"%@_%@",
                                      [[NSLocale preferredLanguages] objectAtIndex:0],
                                      [currentLocale objectForKey:NSLocaleCountryCode]];
-    NSString *deviceName = device.name;
-    if (!deviceName) {
-        deviceName = @"";
+    // Set the device name. But only if running in development mode.
+    NSString *deviceName = @"";
+    if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
+        deviceName = device.name ?: @"";
     }
     NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
     NSNumber *timezoneOffsetSeconds =


### PR DESCRIPTION
This patch only sets `LP_PARAM_DEVICE_NAME` if `[LPConstantsState sharedState].isDevelopmentModeEnabled` is true. If the SDK is not running in development mode, the device name defaults to an empty string.