### PR TITLE
Add applyVars to dev websocket

### DIFF
--- a/Leanplum-SDK/Classes/LeanplumSocket.m
+++ b/Leanplum-SDK/Classes/LeanplumSocket.m
@@ -202,6 +202,10 @@ static dispatch_once_t leanplum_onceToken;
                cancelButtonTitle:NSLocalizedString(@"OK", nil)
                otherButtonTitles:nil
                            block:nil];
+    } else if ([packet.name isEqualToString:@"applyVars"]) {
+        NSDictionary *packetData = packet.dataAsJSON[@"args"][0];
+        [LPVarCache applyVariableDiffs:packetData messages:nil updateRules:nil eventRules:nil
+                              variants:nil regions:nil];
     }
     LP_END_TRY
 }


### PR DESCRIPTION
Support `applyVars` endpoint which is used to preview variable changes on test devices.

This is similar to https://github.com/Leanplum/Leanplum-Android-SDK/pull/91 and relies on https://github.com/Leanplum/Leanplum/pull/209