### PR TITLE
Added the possibility to add a custom locale identifier to the sdk.

### DIFF
--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -257,6 +257,15 @@ typedef enum {
 + (void)setAppVersion:(NSString *)appVersion;
 
 /**
+ * By default, Leanplum reports the language of your app using the [NSLocale preferredLanguages]
+ * in combination with NSLocaleCountryCode value of the [NSLocale currentLocale].
+ * The following format is uphold '%prefferedLanguage%_%countryCode%'.
+ * If you wish to use any other string as the locale
+ * you can call this before you call to {@link start}.
+ */
++ (void)setLocaleString:(nullable NSString *)localeString;
+
+/**
  * @{
  * Syncs resources between Leanplum and the current app.
  * You should only call this once, and before {@link start}.

--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -707,7 +707,9 @@ BOOL inForeground = NO;
         [state.userAttributeChanges removeAllObjects];
     }
     state.calledHandleNotification = NO;
-
+    state.appVersion = nil;
+    state.localeString = nil;
+    
     [[LPInbox sharedState] reset];
 }
 

--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -87,6 +87,8 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
         _initializedMessageTemplates = NO;
         _actionManager = nil;
         _deviceId = nil;
+        _appVersion = nil;
+        _localeString = nil;
         _userAttributeChanges = [NSMutableArray array];
         _stripViewControllerFromState = NO;
         _isScreenTrackingEnabled = NO;
@@ -320,6 +322,15 @@ BOOL inForeground = NO;
     [LPInternalState sharedState].appVersion = appVersion;
     LP_END_TRY
 }
+
+
++ (void)setLocaleString:(NSString *)localeString;
+{
+    LP_TRY
+    [LPInternalState sharedState].localeString = localeString;
+    LP_END_TRY
+}
+
 
 + (void)setAppId:(NSString *)appId withProductionKey:(NSString *)accessKey
 {
@@ -849,11 +860,15 @@ BOOL inForeground = NO;
         versionName = [[[NSBundle mainBundle] infoDictionary]
                        objectForKey:@"CFBundleVersion"];
     }
+    NSString *localeString = [LPInternalState sharedState].localeString;
+    if (!localeString) {
+        NSLocale *currentLocale = [NSLocale currentLocale];
+        localeString = [NSString stringWithFormat:@"%@_%@",
+                        [[NSLocale preferredLanguages] objectAtIndex:0],
+                        [currentLocale objectForKey:NSLocaleCountryCode]];
+    }
+    
     UIDevice *device = [UIDevice currentDevice];
-    NSLocale *currentLocale = [NSLocale currentLocale];
-    NSString *currentLocaleString = [NSString stringWithFormat:@"%@_%@",
-                                     [[NSLocale preferredLanguages] objectAtIndex:0],
-                                     [currentLocale objectForKey:NSLocaleCountryCode]];
     // Set the device name. But only if running in development mode.
     NSString *deviceName = @"";
     if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
@@ -869,7 +884,7 @@ BOOL inForeground = NO;
         LP_PARAM_DEVICE_MODEL: [self platform],
         LP_PARAM_DEVICE_SYSTEM_NAME: device.systemName,
         LP_PARAM_DEVICE_SYSTEM_VERSION: device.systemVersion,
-        LP_KEY_LOCALE: currentLocaleString,
+        LP_KEY_LOCALE: localeString,
         LP_KEY_TIMEZONE: [localTimeZone name],
         LP_KEY_TIMEZONE_OFFSET_SECONDS: timezoneOffsetSeconds,
         LP_KEY_COUNTRY: LP_VALUE_DETECT,

--- a/Leanplum-SDK/Classes/LeanplumInternal.h
+++ b/Leanplum-SDK/Classes/LeanplumInternal.h
@@ -50,6 +50,7 @@
     LPActionManager *_actionManager;
     NSString *_deviceId;
     NSString *_appVersion;
+    NSString * _Nullable _localeString;
     NSMutableArray *_userAttributeChanges;
     BOOL _calledHandleNotification;
 }
@@ -69,6 +70,7 @@
 @property(strong, nonatomic) LPActionManager *actionManager;
 @property(strong, nonatomic) NSString *deviceId;
 @property(strong, nonatomic) NSString *appVersion;
+@property(strong, nonatomic, nullable) NSString *localeString;
 @property(strong, nonatomic) NSMutableArray *userAttributeChanges;
 @property(assign, nonatomic) BOOL isScreenTrackingEnabled;
 @property(assign, nonatomic) BOOL isInterfaceEditingEnabled;


### PR DESCRIPTION
## Proposed Changes


  - Added option to add a custom localeString for the start process
  - Kept default mechanism intact to determine the localeString.
  - Added test to make sure the value is correctly set.
  - Added test to verify the correct values of the parameters.
  - Added resetting of values in the unit test helper methods.

The Android counter part can be found [here](https://github.com/Leanplum/Leanplum-Android-SDK/pull/171) 