### PR TITLE
Add crash monitoring handler

### DIFF
--- a/Leanplum-SDK/Classes/Constants.m
+++ b/Leanplum-SDK/Classes/Constants.m
@@ -24,6 +24,7 @@
 
 #import "Constants.h"
 #import "LeanplumRequest.h"
+#import "Utils.h"
 
 @implementation LPConstantsState
 
@@ -290,6 +291,7 @@ void leanplumIncrementUserCodeBlock(int delta)
 
 void leanplumInternalError(NSException *e)
 {
+    [Utils handleException:e];
     if ([e.name isEqualToString:@"Leanplum Error"]) {
         @throw e;
     }

--- a/Leanplum-SDK/Classes/LPCrashHandler.h
+++ b/Leanplum-SDK/Classes/LPCrashHandler.h
@@ -1,0 +1,19 @@
+//
+//  LPCrashHandler.h
+//  Leanplum-iOS-SDK-source
+//
+//  Created by Mayank Sanganeria on 6/28/18.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol LPCrashReporting
+-(void)reportException:(NSException *)exception;
+@end
+
+@interface LPCrashHandler : NSObject
+
++(instancetype)sharedCrashHandler;
+-(void)reportException:(NSException *)exception;
+
+@end

--- a/Leanplum-SDK/Classes/LPCrashHandler.h
+++ b/Leanplum-SDK/Classes/LPCrashHandler.h
@@ -1,9 +1,25 @@
 //
 //  LPCrashHandler.h
-//  Leanplum-iOS-SDK-source
+//  Leanplum iOS SDK Version 2.0.6
 //
-//  Created by Mayank Sanganeria on 6/28/18.
+//  Copyright (c) 2018 Leanplum, Inc. All rights reserved.
 //
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 #import <Foundation/Foundation.h>
 

--- a/Leanplum-SDK/Classes/LPCrashHandler.m
+++ b/Leanplum-SDK/Classes/LPCrashHandler.m
@@ -53,7 +53,10 @@
 
 -(void)initializeLeanplumReporter
 {
-    _crashReporter = [[NSClassFromString(@"LPCrashReporter") alloc] init];
+    Class LPCrashReporterClass = NSClassFromString(@"LPCrashReporter");
+    if (LPCrashReporterClass) {
+        _crashReporter = [[LPCrashReporterClass alloc] init];
+    }
 }
 
 -(void)reportException:(NSException *)exception

--- a/Leanplum-SDK/Classes/LPCrashHandler.m
+++ b/Leanplum-SDK/Classes/LPCrashHandler.m
@@ -29,12 +29,12 @@
 {
     self = [super init];
     if (self) {
-        [self initializeRaygun];
+        [self initializeRaygunReporter];
     }
     return self;
 }
 
--(void)initializeRaygun
+-(void)initializeRaygunReporter
 {
     _crashReporter = [[NSClassFromString(@"LPRaygunCrashReporter") alloc] init];
     

--- a/Leanplum-SDK/Classes/LPCrashHandler.m
+++ b/Leanplum-SDK/Classes/LPCrashHandler.m
@@ -1,0 +1,50 @@
+//
+//  LPCrashHandler.m
+//  Leanplum-iOS-SDK-source
+//
+//  Created by Mayank Sanganeria on 6/28/18.
+//
+
+#import "LPCrashHandler.h"
+
+@interface LPCrashHandler()
+
+@property (nonatomic, strong) id<LPCrashReporting> crashReporter;
+
+@end
+
+@implementation LPCrashHandler
+
++(instancetype)sharedCrashHandler
+{
+    static LPCrashHandler *sharedCrashHandler = nil;
+    @synchronized(self) {
+        if (!sharedCrashHandler)
+            sharedCrashHandler = [[self alloc] init];
+    }
+    return sharedCrashHandler;
+}
+
+-(instancetype)init
+{
+    self = [super init];
+    if (self) {
+        [self initializeRaygun];
+    }
+    return self;
+}
+
+-(void)initializeRaygun
+{
+    _crashReporter = [[NSClassFromString(@"LPRaygunCrashReporter") alloc] init];
+    
+}
+
+-(void)reportException:(NSException *)exception
+{
+    if (self.crashReporter) {
+        [self.crashReporter reportException:exception];
+    }
+}
+
+@end

--- a/Leanplum-SDK/Classes/LPCrashHandler.m
+++ b/Leanplum-SDK/Classes/LPCrashHandler.m
@@ -46,15 +46,14 @@
 {
     self = [super init];
     if (self) {
-        [self initializeRaygunReporter];
+        [self initializeLeanplumReporter];
     }
     return self;
 }
 
--(void)initializeRaygunReporter
+-(void)initializeLeanplumReporter
 {
-    _crashReporter = [[NSClassFromString(@"LPRaygunCrashReporter") alloc] init];
-    
+    _crashReporter = [[NSClassFromString(@"LPCrashReporter") alloc] init];
 }
 
 -(void)reportException:(NSException *)exception

--- a/Leanplum-SDK/Classes/LPCrashHandler.m
+++ b/Leanplum-SDK/Classes/LPCrashHandler.m
@@ -1,9 +1,25 @@
 //
-//  LPCrashHandler.m
-//  Leanplum-iOS-SDK-source
+//  LPCrashHandler.h
+//  Leanplum iOS SDK Version 2.0.6
 //
-//  Created by Mayank Sanganeria on 6/28/18.
+//  Copyright (c) 2018 Leanplum, Inc. All rights reserved.
 //
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 #import "LPCrashHandler.h"
 
@@ -19,8 +35,9 @@
 {
     static LPCrashHandler *sharedCrashHandler = nil;
     @synchronized(self) {
-        if (!sharedCrashHandler)
+        if (!sharedCrashHandler) {
             sharedCrashHandler = [[self alloc] init];
+        }
     }
     return sharedCrashHandler;
 }

--- a/Leanplum-SDK/Classes/Leanplum.m
+++ b/Leanplum-SDK/Classes/Leanplum.m
@@ -1055,6 +1055,10 @@ BOOL inForeground = NO;
 #endif
     [self maybeRegisterForNotifications];
     LP_END_TRY
+    
+    LP_TRY
+    [Utils initExceptionHandling];
+    LP_END_TRY
 }
 
 // On first run with Leanplum, determine if this app was previously installed without Leanplum.

--- a/Leanplum-SDK/Classes/Utils.h
+++ b/Leanplum-SDK/Classes/Utils.h
@@ -59,7 +59,7 @@
 + (void)initExceptionHandling;
 
 /**
- * Initialize exception handling
+ * Report an exception
  */
 + (void)handleException:(NSException *)exception;
 

--- a/Leanplum-SDK/Classes/Utils.h
+++ b/Leanplum-SDK/Classes/Utils.h
@@ -53,4 +53,14 @@
  */
 + (NSString *)urlEncodedStringFromString:(NSString *)urlString;
 
+/**
+ * Initialize exception handling
+ */
++ (void)initExceptionHandling;
+
+/**
+ * Initialize exception handling
+ */
++ (void)handleException:(NSException *)exception;
+
 @end

--- a/Leanplum-SDK/Classes/Utils.m
+++ b/Leanplum-SDK/Classes/Utils.m
@@ -24,6 +24,7 @@
 
 #import "Utils.h"
 #import <CommonCrypto/CommonDigest.h>
+#import "LPCrashHandler.h"
 
 @implementation Utils
 
@@ -79,6 +80,16 @@
     return [urlString
             stringByAddingPercentEncodingWithAllowedCharacters:
             allowed];
+}
+
++ (void)initExceptionHandling
+{
+    [LPCrashHandler sharedCrashHandler];
+}
+
++ (void)handleException:(NSException *)exception
+{
+    [[LPCrashHandler sharedCrashHandler] reportException:exception];
 }
 
 @end


### PR DESCRIPTION
The iOS SDK needs to report crashes. We will add another repo which will provide different crash reporting services to the main repo. This commit adds the interface for a general crash handler and looks specifically for a raygun provider

