### PR TITLE
Change naming convention to not include "private_" for readonly properties

### DIFF
--- a/Leanplum-SDK/Classes/LPActionArg-Internal.h
+++ b/Leanplum-SDK/Classes/LPActionArg-Internal.h
@@ -9,8 +9,8 @@
 
 @interface LPActionArg ()
 
-@property (readonly, strong) NSString *private_Name;
-@property (readonly, strong) id private_DefaultValue;
-@property (readonly, strong) NSString *private_Kind;
+@property (readonly, strong) NSString *name;
+@property (readonly, strong) id defaultValue;
+@property (readonly, strong) NSString *kind;
 
 @end

--- a/Leanplum-SDK/Classes/LPActionArg.m
+++ b/Leanplum-SDK/Classes/LPActionArg.m
@@ -80,19 +80,4 @@
     return [self argNamed:name with:@(leanplum_colorToInt(defaultValue)) kind:LP_KIND_COLOR];
 }
 
-- (NSString *)name
-{
-    return _name;
-}
-
-- (id)defaultValue
-{
-    return _defaultValue;
-}
-
-- (NSString *)kind
-{
-    return _kind;
-}
-
 @end

--- a/Leanplum-SDK/Classes/LPActionArg.m
+++ b/Leanplum-SDK/Classes/LPActionArg.m
@@ -11,9 +11,9 @@
 
 @implementation LPActionArg : NSObject
 
-@synthesize private_Name=_name;
-@synthesize private_Kind=_kind;
-@synthesize private_DefaultValue=_defaultValue;
+@synthesize name=_name;
+@synthesize kind=_kind;
+@synthesize defaultValue=_defaultValue;
 
 + (LPActionArg *)argNamed:(NSString *)name with:(NSObject *)defaultValue kind:(NSString *)kind
 {

--- a/Leanplum-SDK/Classes/LPActionContext-Internal.h
+++ b/Leanplum-SDK/Classes/LPActionContext-Internal.h
@@ -21,28 +21,22 @@
                          originalMessageId:(NSString *)originalMessageId
                                   priority:(NSNumber *)priority;
 
-@property (readonly, strong) NSString *private_Name;
-@property (readonly, strong) NSString *private_MessageId;
-@property (readonly, strong) NSString *private_OriginalMessageId;
-@property (readonly, strong) NSNumber *private_Priority;
-@property (readonly, strong) NSDictionary *private_Args;
-@property (readonly, strong) LPActionContext *private_ParentContext;
-@property (readonly) int private_ContentVersion;
-@property (readonly, strong) NSString *private_Key;
-@property (readonly) BOOL private_PreventRealtimeUpdating;
-@property (readonly) BOOL private_IsRooted;
-@property (readonly) BOOL private_IsPreview;
+@property (readonly, strong) NSString *name;
+@property (readonly, strong) NSString *messageId;
+@property (readonly, strong) NSString *originalMessageId;
+@property (readonly, strong) NSNumber *priority;
+@property (readonly, strong) NSDictionary *args;
+@property (readonly, strong) LPActionContext *parentContext;
+@property (readonly) int contentVersion;
+@property (readonly, strong) NSString *key;
+@property (readonly) BOOL preventRealtimeUpdating;
+@property (nonatomic, assign) BOOL isRooted;
+@property (nonatomic, assign) BOOL isPreview;
 @property (nonatomic, strong) LPContextualValues *contextualValues;
 
-- (NSString *)messageId;
-- (NSString *)originalMessageId;
-- (NSNumber *)priority;
 - (void)maybeDownloadFiles;
 - (id)objectNamed:(NSString *)name;
 - (void)preventRealtimeUpdating;
-- (void)setIsRooted:(BOOL)value;
-- (void)setIsPreview:(BOOL)preview;
-- (NSDictionary *)args;
 + (void)sortByPriority:(NSMutableArray *)actionContexts;
 
 @end

--- a/Leanplum-SDK/Classes/LPActionContext.m
+++ b/Leanplum-SDK/Classes/LPActionContext.m
@@ -56,21 +56,6 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
     return context;
 }
 
-- (NSString *)messageId
-{
-    return _messageId;
-}
-
-- (NSString *)originalMessageId
-{
-    return _originalMessageId;
-}
-
-- (NSNumber *)priority
-{
-    return _priority;
-}
-
 - (void)preventRealtimeUpdating
 {
     _preventRealtimeUpdating = YES;
@@ -175,11 +160,6 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
 - (NSString *)actionName
 {
     return _name;
-}
-
-- (NSDictionary *)args
-{
-    return _args;
 }
 
 - (void)setProperArgs

--- a/Leanplum-SDK/Classes/LPActionContext.m
+++ b/Leanplum-SDK/Classes/LPActionContext.m
@@ -14,17 +14,15 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
 
 @implementation LPActionContext
 
-@synthesize private_Name=_name;
-@synthesize private_MessageId=_messageId;
-@synthesize private_OriginalMessageId=_originalMessageId;
-@synthesize private_Priority=_priority;
-@synthesize private_Args=_args;
-@synthesize private_ParentContext=_parentContext;
-@synthesize private_ContentVersion=_contentVersion;
-@synthesize private_Key=_key;
-@synthesize private_PreventRealtimeUpdating=_preventRealtimeUpdating;
-@synthesize private_IsRooted=_isRooted;
-@synthesize private_IsPreview=_isPreview;
+@synthesize name=_name;
+@synthesize messageId=_messageId;
+@synthesize originalMessageId=_originalMessageId;
+@synthesize priority=_priority;
+@synthesize args=_args;
+@synthesize parentContext=_parentContext;
+@synthesize contentVersion=_contentVersion;
+@synthesize key=_key;
+@synthesize preventRealtimeUpdating=_preventRealtimeUpdating;
 @synthesize contextualValues=_contextualValues;
 
 + (LPActionContext *)actionContextWithName:(NSString *)name
@@ -76,16 +74,6 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
 - (void)preventRealtimeUpdating
 {
     _preventRealtimeUpdating = YES;
-}
-
-- (void)setIsRooted:(BOOL)value
-{
-    _isRooted = value;
-}
-
-- (void)setIsPreview:(BOOL)value
-{
-    _isPreview = value;
 }
 
 - (NSDictionary *)defaultValues

--- a/Leanplum-SDK/Classes/LPActionManager.m
+++ b/Leanplum-SDK/Classes/LPActionManager.m
@@ -764,12 +764,12 @@ static dispatch_once_t leanplum_onceToken;
         }
 #endif
 
-        NSString *messageId = [context private_MessageId];
+        NSString *messageId = context.messageId;
 
         NSDictionary *messageConfig = LPVarCache.messageDiffs[messageId];
         
         NSNumber *countdown = messageConfig[@"countdown"];
-        if ([context private_IsPreview]) {
+        if (context.isPreview) {
             countdown = @(5.0);
         }
         if (![countdown.class isSubclassOfClass:NSNumber.class]) {
@@ -784,7 +784,7 @@ static dispatch_once_t leanplum_onceToken;
         NSArray *notifications = [app scheduledLocalNotifications];
         for (UILocalNotification *notification in notifications) {
             NSString *messageId = [LPActionManager messageIdFromUserInfo:[notification userInfo]];
-            if ([messageId isEqualToString:[context private_MessageId]]) {
+            if ([messageId isEqualToString:context.messageId]) {
                 NSComparisonResult comparison = [notification.fireDate compare:eta];
                 if (comparison == NSOrderedAscending) {
                     return NO;
@@ -874,7 +874,7 @@ static dispatch_once_t leanplum_onceToken;
         BOOL didCancel = NO;
         for (UILocalNotification *notification in notifications) {
             NSString *messageId = [LPActionManager messageIdFromUserInfo:[notification userInfo]];
-            if ([messageId isEqualToString:[context private_MessageId]]) {
+            if ([messageId isEqualToString:context.messageId]) {
                 [app cancelLocalNotification:notification];
                 if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
                     LPLog(LPInfo, @"Cancelled notification");

--- a/Leanplum-SDK/Classes/LPVar-Internal.h
+++ b/Leanplum-SDK/Classes/LPVar-Internal.h
@@ -12,20 +12,20 @@
 - (instancetype)initWithName:(NSString *)name withComponents:(NSArray *)components
             withDefaultValue:(NSObject *)defaultValue withKind:(NSString *)kind;
 
-@property (readonly) BOOL private_IsInternal;
-@property (readonly, strong) NSString *private_Name;
-@property (readonly, strong) NSArray *private_NameComponents;
-@property (readonly, strong) NSString *private_StringValue;
-@property (readonly, strong) NSNumber *private_NumberValue;
-@property (readonly) BOOL private_HadStarted;
-@property (readonly, strong) id private_Value;
-@property (readonly, strong) id private_DefaultValue;
-@property (readonly, strong) NSString *private_Kind;
-@property (readonly, strong) NSMutableArray *private_FileReadyBlocks;
-@property (readonly, strong) NSMutableArray *private_valueChangedBlocks;
-@property (readonly) BOOL private_FileIsPending;
-@property (nonatomic, unsafe_unretained) id <LPVarDelegate> private_Delegate;
-@property (readonly) BOOL private_HasChanged;
+@property (readonly) BOOL isInternal;
+@property (readonly, strong) NSString *name;
+@property (readonly, strong) NSArray *nameComponents;
+@property (readonly, strong) NSString *stringValue;
+@property (readonly, strong) NSNumber *numberValue;
+@property (readonly) BOOL hadStarted;
+@property (readonly, strong) id value;
+@property (readonly, strong) id defaultValue;
+@property (readonly, strong) NSString *kind;
+@property (readonly, strong) NSMutableArray *fileReadyBlocks;
+@property (readonly, strong) NSMutableArray *valueChangedBlocks;
+@property (readonly) BOOL fileIsPending;
+@property (nonatomic, unsafe_unretained) id <LPVarDelegate> delegate;
+@property (readonly) BOOL hasChanged;
 
 - (void) update;
 - (void) cacheComputedValues;

--- a/Leanplum-SDK/Classes/LPVar.m
+++ b/Leanplum-SDK/Classes/LPVar.m
@@ -272,26 +272,6 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 
 #pragma mark Basic accessors
 
-- (NSString *)name
-{
-    return _name;
-}
-
-- (NSArray *)nameComponents
-{
-    return _nameComponents;
-}
-
-- (id)defaultValue
-{
-    return _defaultValue;
-}
-
-- (NSString *)kind
-{
-    return _kind;
-}
-
 - (void)triggerValueChanged
 {
     LP_BEGIN_USER_CODE

--- a/Leanplum-SDK/Classes/LPVar.m
+++ b/Leanplum-SDK/Classes/LPVar.m
@@ -13,20 +13,20 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 
 @implementation LPVar
 
-@synthesize private_IsInternal=_isInternal;
-@synthesize private_Name=_name;
-@synthesize private_NameComponents=_nameComponents;
-@synthesize private_StringValue=_stringValue;
-@synthesize private_NumberValue=_numberValue;
-@synthesize private_HadStarted=_hadStarted;
-@synthesize private_Value=_value;
-@synthesize private_DefaultValue=_defaultValue;
-@synthesize private_Kind=_kind;
-@synthesize private_FileReadyBlocks=_fileReadyBlocks;
-@synthesize private_valueChangedBlocks=_valueChangedBlocks;
-@synthesize private_FileIsPending=_fileIsPending;
-@synthesize private_Delegate=_delegate;
-@synthesize private_HasChanged=_hasChanged;
+@synthesize isInternal=_isInternal;
+@synthesize name=_name;
+@synthesize nameComponents=_nameComponents;
+@synthesize stringValue=_stringValue;
+@synthesize numberValue=_numberValue;
+@synthesize hadStarted=_hadStarted;
+@synthesize value=_value;
+@synthesize defaultValue=_defaultValue;
+@synthesize kind=_kind;
+@synthesize fileReadyBlocks=_fileReadyBlocks;
+@synthesize valueChangedBlocks=_valueChangedBlocks;
+@synthesize fileIsPending=_fileIsPending;
+@synthesize delegate=_delegate;
+@synthesize hasChanged=_hasChanged;
 
 +(BOOL)printedCallbackWarning
 {
@@ -295,9 +295,9 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 - (void)triggerValueChanged
 {
     LP_BEGIN_USER_CODE
-    if (self.private_Delegate &&
-        [self.private_Delegate respondsToSelector:@selector(valueDidChange:)]) {
-        [self.private_Delegate valueDidChange:self];
+    if (self.delegate &&
+        [self.delegate respondsToSelector:@selector(valueDidChange:)]) {
+        [self.delegate valueDidChange:self];
     }
     
     for (LeanplumVariablesChangedBlock block in _valueChangedBlocks.copy) {
@@ -329,9 +329,9 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 {
     _fileIsPending = NO;
     LP_BEGIN_USER_CODE
-    if (self.private_Delegate &&
-        [self.private_Delegate respondsToSelector:@selector(fileIsReady:)]) {
-        [self.private_Delegate fileIsReady:self];
+    if (self.delegate &&
+        [self.delegate respondsToSelector:@selector(fileIsReady:)]) {
+        [self.delegate fileIsReady:self];
     }
     
     for (LeanplumVariablesChangedBlock block in _fileReadyBlocks.copy) {
@@ -360,7 +360,7 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 - (void)setDelegate:(id<LPVarDelegate>)delegate
 {
     LP_TRY
-    self.private_Delegate = delegate;
+    self.delegate = delegate;
     if ([LPInternalState sharedState].hasStarted && !_fileIsPending) {
         [self triggerFileIsReady];
     }


### PR DESCRIPTION
Read only properties don't need to be named "private_" since they cannot be changed anyway (would throw compiler error)