### PR TITLE
LP-9384: move helper method to class file that uses it

### DIFF
--- a/Example/Tests/Classes/LPMessageTemplatesClassTest.m
+++ b/Example/Tests/Classes/LPMessageTemplatesClassTest.m
@@ -38,6 +38,7 @@
 @interface LPMessageTemplatesClass (Test)
 + (UIImage *)imageFromColor:(UIColor *)color;
 + (UIImage *)dismissImage:(UIColor *)color withSize:(int)size;
++ (NSString *)urlEncodedStringFromString:(NSString *)urlString;
 
 - (void)setupPopupLayout:(BOOL)isFullscreen isPushAskToAsk:(BOOL)isPushAskToAsk;
 - (void)updatePopupLayout;
@@ -123,6 +124,13 @@
     XCTAssertNotNil(acceptButton);
     id cancelButton = [[LPMessageTemplatesClass sharedTemplates] valueForKey:@"_cancelButton"];
     XCTAssertNotNil(cancelButton);
+}
+
+- (void)test_urlEncodedStringFromString {
+    XCTAssertEqualObjects([LPMessageTemplatesClass urlEncodedStringFromString:@"http://www.leanplum.com"], @"http://www.leanplum.com");
+    XCTAssertEqualObjects([LPMessageTemplatesClass urlEncodedStringFromString:@"http://www.leanplum.com?q=simple_english1&test=2"], @"http://www.leanplum.com?q=simple_english1&test=2");
+    XCTAssertEqualObjects([LPMessageTemplatesClass urlEncodedStringFromString:@"https://ramsey.tfaforms.net/356302?id={}"], @"https://ramsey.tfaforms.net/356302?id=%7B%7D");
+    XCTAssertEqualObjects([LPMessageTemplatesClass urlEncodedStringFromString:@"lomotif://music/月亮"], @"lomotif://music/%E6%9C%88%E4%BA%AE");
 }
 
 @end

--- a/Example/Tests/Classes/LPUtilsTest.m
+++ b/Example/Tests/Classes/LPUtilsTest.m
@@ -79,11 +79,4 @@
     XCTAssertEqualObjects(base64String, expectedSring);
 }
 
-- (void)test_urlEncodedStringFromString {
-    XCTAssertEqualObjects([Utils urlEncodedStringFromString:@"http://www.leanplum.com"], @"http://www.leanplum.com");
-    XCTAssertEqualObjects([Utils urlEncodedStringFromString:@"http://www.leanplum.com?q=simple_english1&test=2"], @"http://www.leanplum.com?q=simple_english1&test=2");
-    XCTAssertEqualObjects([Utils urlEncodedStringFromString:@"https://ramsey.tfaforms.net/356302?id={}"], @"https://ramsey.tfaforms.net/356302?id=%7B%7D");
-    XCTAssertEqualObjects([Utils urlEncodedStringFromString:@"lomotif://music/月亮"], @"lomotif://music/%E6%9C%88%E4%BA%AE");
-}
-
 @end

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -29,7 +29,6 @@
 #import "LPMessageTemplates.h"
 #import <QuartzCore/QuartzCore.h>
 #import <StoreKit/StoreKit.h>
-#import "Utils.h"
 
 #define APP_NAME (([[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]) ?: \
     ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"]))
@@ -324,7 +323,7 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
              withResponder:^BOOL(LPActionContext *context) {
                  @try {
                      dispatch_async(dispatch_get_main_queue(), ^{
-                         NSString *encodedURLString = [Utils urlEncodedStringFromString:[context stringNamed:LPMT_ARG_URL]];
+                         NSString *encodedURLString = [[self class] urlEncodedStringFromString:[context stringNamed:LPMT_ARG_URL]];
                          NSURL *url = [NSURL URLWithString: encodedURLString];
                          if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
                              [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
@@ -1439,5 +1438,19 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
 }
 
 #endif
+
+/**
+ * Helper method
+ */
+
++ (NSString *)urlEncodedStringFromString:(NSString *)urlString {
+    NSString *unreserved = @":-._~/?&=";
+    NSMutableCharacterSet *allowed = [NSMutableCharacterSet
+                                      alphanumericCharacterSet];
+    [allowed addCharactersInString:unreserved];
+    return [urlString
+            stringByAddingPercentEncodingWithAllowedCharacters:
+            allowed];
+}
 
 @end

--- a/Leanplum-SDK/Classes/Utilities/Utils.h
+++ b/Leanplum-SDK/Classes/Utilities/Utils.h
@@ -48,12 +48,6 @@
 + (NSString *)base64EncodedStringFromData:(NSData *)data;
 
 /**
- * Returns unicode encoded string for supporting international
- * characters in URL
- */
-+ (NSString *)urlEncodedStringFromString:(NSString *)urlString;
-
-/**
  * Initialize exception handling
  */
 + (void)initExceptionHandling;

--- a/Leanplum-SDK/Classes/Utilities/Utils.m
+++ b/Leanplum-SDK/Classes/Utilities/Utils.m
@@ -72,16 +72,6 @@
 
 }
 
-+(NSString *)urlEncodedStringFromString:(NSString *)urlString {
-    NSString *unreserved = @":-._~/?&=";
-    NSMutableCharacterSet *allowed = [NSMutableCharacterSet
-                                      alphanumericCharacterSet];
-    [allowed addCharactersInString:unreserved];
-    return [urlString
-            stringByAddingPercentEncodingWithAllowedCharacters:
-            allowed];
-}
-
 + (void)initExceptionHandling
 {
     [LPExceptionHandler sharedExceptionHandler];


### PR DESCRIPTION
"LPMessageTemplates.h" is one of 4 publicly exposed files when we package the SDK. It needed a utility function that I previously added to Util.h. However, this is a helper method that is not used elsewhere so it can be moved directly into "LPMessageTemplates.h"

The reason to make this change is that we were referencing the "Util.h" file from "LPMessageTemplates.h" and this was breaking compilation, since "Util.h" is not publicly exposed