### PR TITLE
Fix deadlock initializing sharedTemplates

### DIFF
--- a/Example/Tests/Classes/LPMessageTemplatesClassTest.m
+++ b/Example/Tests/Classes/LPMessageTemplatesClassTest.m
@@ -82,7 +82,7 @@
     XCTAssertNotNil(image);
 }
 
--(void)test_shared_templates
+-(void)test_shared_templates_creation
 {
     // Previously, this was causing a deadlock.
     [LPMessageTemplatesClass sharedTemplates];

--- a/Example/Tests/Classes/LPMessageTemplatesClassTest.m
+++ b/Example/Tests/Classes/LPMessageTemplatesClassTest.m
@@ -82,6 +82,12 @@
     XCTAssertNotNil(image);
 }
 
+-(void)test_shared_templates
+{
+    // Previously, this was causing a deadlock.
+    [LPMessageTemplatesClass sharedTemplates];
+}
+
 - (void)test_popup_setup
 {
     // This stub have to be removed when start command is successfully executed.

--- a/Leanplum-SDK/Classes/Internal/LPInternalState.h
+++ b/Leanplum-SDK/Classes/Internal/LPInternalState.h
@@ -20,7 +20,7 @@
 @property(assign, nonatomic) NSUncaughtExceptionHandler *customExceptionHandler;
 @property(strong, nonatomic) LPRegisterDevice *registration;
 @property(assign, nonatomic) BOOL calledStart, hasStarted, hasStartedAndRegisteredAsDeveloper,
-startSuccessful, issuedStart, initializedMessageTemplates, stripViewControllerFromState;
+startSuccessful, issuedStart, stripViewControllerFromState;
 @property(strong, nonatomic) LPActionManager *actionManager;
 @property(strong, nonatomic) NSString *deviceId;
 @property(strong, nonatomic) NSString *appVersion;

--- a/Leanplum-SDK/Classes/Internal/LPInternalState.m
+++ b/Leanplum-SDK/Classes/Internal/LPInternalState.m
@@ -39,7 +39,6 @@
         _hasStarted = NO;
         _hasStartedAndRegisteredAsDeveloper = NO;
         _startSuccessful = NO;
-        _initializedMessageTemplates = NO;
         _actionManager = nil;
         _deviceId = nil;
         _userAttributeChanges = [NSMutableArray array];

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -1547,10 +1547,6 @@ BOOL inForeground = NO;
     }
 
     LP_TRY
-    // This should be done elsewhere. I don't know where.
-    if (![LPInternalState sharedState].initializedMessageTemplates) {
-        [LPMessageTemplatesClass sharedTemplates];
-    }
     [[LPInternalState sharedState].actionBlocks removeObjectForKey:name];
     [[LPVarCache sharedCache] registerActionDefinition:name ofKind:kind withArguments:args andOptions:options];
     if (responder) {

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -723,7 +723,6 @@ BOOL inForeground = NO;
         [self throwError:@"Already called start."];
     }
 
-    state.initializedMessageTemplates = YES;
     [LPMessageTemplatesClass sharedTemplates];
     attributes = [self validateAttributes:attributes named:@"userAttributes" allowLists:YES];
     if (attributes != nil) {
@@ -1548,8 +1547,8 @@ BOOL inForeground = NO;
     }
 
     LP_TRY
+    // This should be done elsewhere. I don't know where.
     if (![LPInternalState sharedState].initializedMessageTemplates) {
-        [LPInternalState sharedState].initializedMessageTemplates = YES;
         [LPMessageTemplatesClass sharedTemplates];
     }
     [[LPInternalState sharedState].actionBlocks removeObjectForKey:name];

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -188,9 +188,6 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     static LPMessageTemplatesClass *sharedTemplates = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        // This calls defineAction,
-        // and is called by defineAction if initializedMessageTemplates is NO.
-        [LPInternalState sharedState].initializedMessageTemplates = YES;
         sharedTemplates = [[self alloc] init];
     });
 

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -27,7 +27,6 @@
 //  THE SOFTWARE.
 
 #import "LPMessageTemplates.h"
-#import "Internal/LPInternalState.h"
 #import <QuartzCore/QuartzCore.h>
 #import <StoreKit/StoreKit.h>
 

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -27,6 +27,7 @@
 //  THE SOFTWARE.
 
 #import "LPMessageTemplates.h"
+#import "Internal/LPInternalState.h"
 #import <QuartzCore/QuartzCore.h>
 #import <StoreKit/StoreKit.h>
 
@@ -187,6 +188,9 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     static LPMessageTemplatesClass *sharedTemplates = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+        // This calls defineAction,
+        // and is called by defineAction if initializedMessageTemplates is NO.
+        [LPInternalState sharedState].initializedMessageTemplates = YES;
         sharedTemplates = [[self alloc] init];
     });
 


### PR DESCRIPTION
https://leanplum.atlassian.net/browse/E2-1492

sharedTemplates is using an anti-singleton-anti-pattern. It is a dependency in its own initialization path. This pattern will remain because I don't know the right way to initialize it elsewhere. I centralized the flag to mark it as initialized so any callers can't cause deadlock, which was happening.