### PR TITLE
Added support to request authorization for notifications directly w/o using Leanplum dashboard

### DIFF
--- a/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
@@ -62,9 +62,12 @@ typedef enum {
 
 + (LPActionManager*) sharedManager;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000 && LP_NOT_TV
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;
 #endif
+#pragma clang diagnostic pop
 
 + (void)getForegroundRegionNames:(NSMutableSet **)foregroundRegionNames
         andBackgroundRegionNames:(NSMutableSet **)backgroundRegionNames;

--- a/Leanplum-SDK/Classes/Features/Actions/LPUIAlert.h
+++ b/Leanplum-SDK/Classes/Features/Actions/LPUIAlert.h
@@ -38,6 +38,8 @@ typedef void (^LeanplumUIAlertCompletionBlock) (NSInteger buttonIndex);
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if LP_NOT_TV
 @interface LPUIAlertView : UIAlertView <UIAlertViewDelegate> {
   @public
@@ -45,3 +47,4 @@ typedef void (^LeanplumUIAlertCompletionBlock) (NSInteger buttonIndex);
 }
 @end
 #endif
+#pragma clang diagnostic pop

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -414,10 +414,10 @@ BOOL inForeground = NO;
     [self startWithUserId:userId userAttributes:attributes responseHandler:nil];
 }
 
-+ (void)requestAuthorization
++ (void)requestAuthorizationWithResponseHandler:(LeanplumRequestAuthorizationBlock)response;
 {
 #if LP_NOT_TV
-    [[LPMessageTemplatesClass sharedTemplates] enableSystemPush];
+    [[LPMessageTemplatesClass sharedTemplates] requestAuthorizationWithResponseHandler:response];
 #endif
 }
 

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -414,6 +414,13 @@ BOOL inForeground = NO;
     [self startWithUserId:userId userAttributes:attributes responseHandler:nil];
 }
 
++ (void)requestAuthorization
+{
+#if LP_NOT_TV
+    [[LPMessageTemplatesClass sharedTemplates] enableSystemPush];
+#endif
+}
+
 + (void)triggerStartIssued
 {
     [LPInternalState sharedState].issuedStart = YES;

--- a/Leanplum-SDK/Classes/LPMessageTemplates.h
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.h
@@ -41,6 +41,7 @@
 #if LP_NOT_TV
 - (void)disableAskToAsk;
 - (void)refreshPushPermissions;
+- (void)enableSystemPush;
 #endif
 
 @end

--- a/Leanplum-SDK/Classes/LPMessageTemplates.h
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.h
@@ -41,7 +41,7 @@
 #if LP_NOT_TV
 - (void)disableAskToAsk;
 - (void)refreshPushPermissions;
-- (void)enableSystemPush;
+- (void)requestAuthorizationWithResponseHandler:(LeanplumRequestAuthorizationBlock)response;
 #endif
 
 @end

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -879,7 +879,7 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     return enabled;
 }
 
-- (void)enableSystemPush
+- (void)requestAuthorizationWithResponseHandler:(LeanplumRequestAuthorizationBlock)response
 {
     // The commented lines below are an alternative for iOS 8 that will deep link to the app in
     // device Settings.
@@ -891,6 +891,9 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     if (block) {
         // If the app used [Leanplum setPushSetup:...], call the block.
         block();
+        if (response) {
+            response(false, nil);
+        }
         return;
     }
     // Otherwise use boilerplate code from docs.
@@ -913,6 +916,9 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
                          NSLog(@"Leanplum: Failed to request authorization for user "
                                "notifications: %@", error);
                      }
+                     if (response) {
+                        response(granted, error);
+                     }
                  });
         }
         [[UIApplication sharedApplication] registerForRemoteNotifications];
@@ -933,6 +939,11 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
 #pragma clang diagnostic pop
          UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge];
     }
+}
+
+- (void)enableSystemPush
+{
+    [self requestAuthorizationWithResponseHandler:nil];
 }
 
 // If notification were enabled by Leanplum's "Push Ask to Ask" or "Register For Push",

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -327,6 +327,15 @@ typedef enum {
 /**@}*/
 
 /**
+ * Request authorization to interact with the user when local or remote notifications
+ * are delivered to the user's device.
+ * This should only be used if your app does not intend to use the Leanplum dashboard
+ * as the mechanism to push authorization requests. Otherwise, please use the Push 
+ * Pre-Permission or Register For Push messages from the dashboard.
+ */
++ (void)requestAuthorization;
+
+/**
  * @{
  * Returns whether or not Leanplum has finished starting.
  */

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -130,6 +130,7 @@ name = [LPVar define:[@#name stringByReplacingOccurrencesOfString:@"_" withStrin
  * @{
  */
 typedef void (^LeanplumStartBlock)(BOOL success);
+typedef void (^LeanplumRequestAuthorizationBlock)(BOOL granted, NSError *__nullable error);
 typedef void (^LeanplumInterfaceChangedBlock)(void);
 typedef void (^LeanplumSetLocationBlock)(BOOL success);
 // Returns whether the action was handled.
@@ -333,7 +334,7 @@ typedef enum {
  * as the mechanism to push authorization requests. Otherwise, please use the Push 
  * Pre-Permission or Register For Push messages from the dashboard.
  */
-+ (void)requestAuthorization;
++ (void)requestAuthorizationWithResponseHandler:(LeanplumRequestAuthorizationBlock)response;
 
 /**
  * @{


### PR DESCRIPTION
## Proposed Changes

  - Add support to request authorization for notifications.

## Why?

Our app already has a "soft ask" modal with a very specific "look and feel" which can not be replicated via the Leanplum dashboard. It is also displayed in a very specific flow which _may_ not be possible using the "Display when" conditional configuration. Therefore, I am requesting to request authorization, bypassing the Leanplum dashboard and obviating the need for a Push Pre-Permission messages in a very specific context, so that I can get the exact behavior required by business.

All this being said, we still want the ability to send Push Pre-Permission messages in some contexts. This change ensures that the Leanplum SDK continues to stay in control of the process of calling `registerForRemoteNotifications` as well as ensuring its internal state is consistent with the reality of iOS's state, in regards to whether the modal was displayed or not.