### PR TITLE
Fix the mistaken deletion in cache

### DIFF
--- a/Leanplum-SDK/Classes/Features/Variables/LPVarCache.m
+++ b/Leanplum-SDK/Classes/Features/Variables/LPVarCache.m
@@ -488,6 +488,7 @@ static dispatch_once_t leanplum_onceToken;
         if (messages_) {
             // Store messages.
             self.messageDiffs = messages_;
+            self.messages = [NSMutableDictionary dictionary];
             for (NSString *name in messages_) {
                 NSDictionary *messageConfig = messages_[name];
                 NSMutableDictionary *newConfig = [messageConfig mutableCopy];


### PR DESCRIPTION
Fixes #
Readded the line to instantiate the new messages diff directory. Avoid storing the previous cached values.

## Proposed Changes

  -
  -
  -

