### PR TITLE
E2-1736: Message archive handles all kinds of text

### DIFF
--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -49,6 +49,8 @@
 + (NSSet<NSString *> *)parseEnabledCountersFromResponse:(NSDictionary *)response;
 + (NSSet<NSString *> *)parseEnabledFeatureFlagsFromResponse:(NSDictionary *)response;
 + (void)triggerMessageDisplayed:(LPActionContext *)context;
++ (LPMessageArchiveData *)messageArchiveDataFromContext:(LPActionContext *)context;
++ (NSString *)messageBodyFromContext:(LPActionContext *)context;
 
 + (void)trackGeofence:(LPGeofenceEventType *)event withValue:(double)value andInfo:(NSString *)info andArgs:(NSDictionary *)args andParameters:(NSDictionary *)params;
 
@@ -1833,6 +1835,62 @@
     [Leanplum triggerMessageDisplayed:actionContext];
 
     XCTAssertTrue(blockCalled);
+}
+
+/**
+ * Test that method messageBodyFromContext gets the correct message body for string.
+ */
+-(void)test_messageBodyFromContextGetsCorrectBodyForString
+{
+    NSString *messageID = @"testMessageID";
+    NSString *messageBody = @"testMessageBody";
+    NSString *recipientUserID = @"recipientUserID";
+
+    LPActionContext *actionContext = [[LPActionContext alloc] init];
+    id actionContextMock = OCMPartialMock(actionContext);
+
+    OCMStub([actionContextMock messageId]).andReturn(messageID);
+    OCMStub([actionContextMock args]).andReturn(@{@"Message":messageBody});
+
+    XCTAssertTrue([[Leanplum messageBodyFromContext:actionContext] isEqualToString:messageBody]);
+}
+
+/**
+ * Test that method messageBodyFromContext gets the correct message body for
+ * dictionary with key "Text".
+ */
+-(void)test_messageBodyFromContextGetsCorrectBodyForDictionaryKeyText
+{
+    NSString *messageID = @"testMessageID";
+    NSString *messageBody = @"testMessageBody";
+    NSString *recipientUserID = @"recipientUserID";
+
+    LPActionContext *actionContext = [[LPActionContext alloc] init];
+    id actionContextMock = OCMPartialMock(actionContext);
+
+    OCMStub([actionContextMock messageId]).andReturn(messageID);
+    OCMStub([actionContextMock args]).andReturn(@{@"Message":@{@"Text":messageBody}});
+
+    XCTAssertTrue([[Leanplum messageBodyFromContext:actionContext] isEqualToString:messageBody]);
+}
+
+/**
+ * Test that method messageBodyFromContext gets the correct message body for
+ * dictionary with key "Text Value".
+ */
+-(void)test_messageBodyFromContextGetsCorrectBodyForDictionaryKeyTextValue
+{
+    NSString *messageID = @"testMessageID";
+    NSString *messageBody = @"testMessageBody";
+    NSString *recipientUserID = @"recipientUserID";
+
+    LPActionContext *actionContext = [[LPActionContext alloc] init];
+    id actionContextMock = OCMPartialMock(actionContext);
+
+    OCMStub([actionContextMock messageId]).andReturn(messageID);
+    OCMStub([actionContextMock args]).andReturn(@{@"Message":@{@"Text Value":messageBody}});
+
+    XCTAssertTrue([[Leanplum messageBodyFromContext:actionContext] isEqualToString:messageBody]);
 }
 
 @end

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -518,7 +518,7 @@ BOOL inForeground = NO;
     LP_END_USER_CODE
 }
 
-+(LPMessageArchiveData *) messageArchiveDataFromContext:(LPActionContext *)context {
++ (LPMessageArchiveData *)messageArchiveDataFromContext:(LPActionContext *)context {
     NSString *messageID = context.messageId;
     NSString *messageBody = [self messageBodyFromContext:context];
     NSString *recipientUserID = [Leanplum userId];
@@ -530,7 +530,7 @@ BOOL inForeground = NO;
                                           deliveryDateTime:deliveryDateTime];
 }
 
-+(NSString *)messageBodyFromContext:(LPActionContext *)context {
++ (NSString *)messageBodyFromContext:(LPActionContext *)context {
     NSString *messageBody = @"";
     NSString *messageKey = @"Message";
     id messageObject = [context.args valueForKey:messageKey];

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -510,34 +510,38 @@ BOOL inForeground = NO;
 + (void)triggerMessageDisplayed:(LPActionContext *)context
 {
     LP_BEGIN_USER_CODE
-    NSString *messageID = context.messageId;
-    NSString *messageKey = @"Message";
-    NSString *messageBody = [self messageBodyFromContext:context];
-    NSString *recipientUserID = [Leanplum userId];
-    NSDate *deliveryDateTime = [NSDate date];
+    LPMessageArchiveData *messageArchiveData = [self messageArchiveDataFromContext:context];
     for (LeanplumMessageDisplayedCallbackBlock block in [LPInternalState sharedState]
          .messageDisplayedBlocks.copy) {
-        LPMessageArchiveData *messageArchiveData = [[LPMessageArchiveData alloc]
-                                                    initWithMessageID: messageID
-                                                    messageBody:messageBody
-                                                    recipientUserID:recipientUserID
-                                                    deliveryDateTime:deliveryDateTime];
         block(messageArchiveData);
     }
     LP_END_USER_CODE
 }
 
++(LPMessageArchiveData *) messageArchiveDataFromContext:(LPActionContext *)context {
+    NSString *messageID = context.messageId;
+    NSString *messageBody = [self messageBodyFromContext:context];
+    NSString *recipientUserID = [Leanplum userId];
+    NSDate *deliveryDateTime = [NSDate date];
+
+    return [[LPMessageArchiveData alloc] initWithMessageID: messageID
+                                               messageBody:messageBody
+                                           recipientUserID:recipientUserID
+                                          deliveryDateTime:deliveryDateTime];
+}
+
 +(NSString *)messageBodyFromContext:(LPActionContext *)context {
     NSString *messageBody = @"";
+    NSString *messageKey = @"Message";
     id messageObject = [context.args valueForKey:messageKey];
     if (messageObject) {
         if ([messageObject isKindOfClass:[NSString class]]) {
             messageBody = messageObject;
         } else if ([messageObject isKindOfClass:[NSDictionary class]]) {
             NSDictionary *messageDict = (NSDictionary *) messageObject;
-            if ([messageDict objectForKey:@"Text"]) {
+            if ([[messageDict objectForKey:@"Text"] isKindOfClass:[NSString class]]) {
                 messageBody = [messageDict objectForKey:@"Text"];
-            } else if ([messageDict objectForKey:@"Text Value"]) {
+            } else if ([[messageDict objectForKey:@"Text Value"] isKindOfClass:[NSString class]]) {
                 messageBody = [messageDict objectForKey:@"Text Value"];
             }
         }

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -512,15 +512,7 @@ BOOL inForeground = NO;
     LP_BEGIN_USER_CODE
     NSString *messageID = context.messageId;
     NSString *messageKey = @"Message";
-    NSString *messageBody = @"";
-    id messageObject = [context.args valueForKey:messageKey];
-    if (messageObject) {
-        if ([messageObject isKindOfClass:[NSString class]]) {
-            messageBody = messageObject;
-        } else if ([messageObject isKindOfClass:[NSDictionary class]]) {
-            // fill in
-        }
-    }
+    NSString *messageBody = [self messageBodyFromContext:context];
     NSString *recipientUserID = [Leanplum userId];
     NSDate *deliveryDateTime = [NSDate date];
     for (LeanplumMessageDisplayedCallbackBlock block in [LPInternalState sharedState]
@@ -533,6 +525,24 @@ BOOL inForeground = NO;
         block(messageArchiveData);
     }
     LP_END_USER_CODE
+}
+
++(NSString *)messageBodyFromContext:(LPActionContext *)context {
+    NSString *messageBody = @"";
+    id messageObject = [context.args valueForKey:messageKey];
+    if (messageObject) {
+        if ([messageObject isKindOfClass:[NSString class]]) {
+            messageBody = messageObject;
+        } else if ([messageObject isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *messageDict = (NSDictionary *) messageObject;
+            if ([messageDict objectForKey:@"Text"]) {
+                messageBody = [messageDict objectForKey:@"Text"];
+            } else if ([messageDict objectForKey:@"Text Value"]) {
+                messageBody = [messageDict objectForKey:@"Text Value"];
+            }
+        }
+    }
+    return messageBody;
 }
 
 + (void)triggerAction:(LPActionContext *)context

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -513,8 +513,13 @@ BOOL inForeground = NO;
     NSString *messageID = context.messageId;
     NSString *messageKey = @"Message";
     NSString *messageBody = @"";
-    if ([context.args valueForKey:messageKey]) {
-        messageBody = [context.args valueForKey:messageKey];
+    id messageObject = [context.args valueForKey:messageKey];
+    if (messageObject) {
+        if ([messageObject isKindOfClass:[NSString class]]) {
+            messageBody = messageObject;
+        } else if ([messageObject isKindOfClass:[NSDictionary class]]) {
+            // fill in
+        }
     }
     NSString *recipientUserID = [Leanplum userId];
     NSDate *deliveryDateTime = [NSDate date];


### PR DESCRIPTION
For Push message archiving, I had assumed that message["body"] is always a string. However, this is an incorrect assumption. For certain message types, message["body"] is a dictionary. We need to change the code to handle all the different kinds of messages.