### PR TITLE
Verify tag during deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 - pod install --project-directory=Example
 
 before_deploy:
+- ./Tools/verifyTag.sh
 - ./build.sh
 
 deploy:

--- a/Tools/verifyTag.sh
+++ b/Tools/verifyTag.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+tag=`git tag --points-at HEAD`
+version=`cat sdk-version.txt`
+echo $tag
+echo $version
+if [ "$tag" == "$version" ]; then
+	echo "Tag matches version. Moving forward with deploy"
+else
+	echo "Tag verification failed"
+	exit 1
+fi


### PR DESCRIPTION
When deploying, we want the build machine to fail if the tag and the sdk-version.txt files are out of sync