### PR TITLE
Silences deprecation warnings in header files

### DIFF
--- a/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
@@ -63,7 +63,11 @@ typedef enum {
 + (LPActionManager*) sharedManager;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000 && LP_NOT_TV
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;
+#pragma clang diagnostic pop
 #endif
 
 + (void)getForegroundRegionNames:(NSMutableSet **)foregroundRegionNames

--- a/Leanplum-SDK/Classes/Features/Actions/LPUIAlert.h
+++ b/Leanplum-SDK/Classes/Features/Actions/LPUIAlert.h
@@ -39,9 +39,13 @@ typedef void (^LeanplumUIAlertCompletionBlock) (NSInteger buttonIndex);
 @end
 
 #if LP_NOT_TV
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 @interface LPUIAlertView : UIAlertView <UIAlertViewDelegate> {
   @public
     LeanplumUIAlertCompletionBlock block;
 }
 @end
+#pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Objective-C header warnings are not inhibited when integrating through CocoaPods into a Swift project, so I had to add this to silence them.