### PR TITLE
remove tvos deployment target

### DIFF
--- a/Leanplum-iOS-SDK.podspec
+++ b/Leanplum-iOS-SDK.podspec
@@ -23,7 +23,6 @@ Analytics.
   s.requires_arc = true
   s.source = { :git => 'https://github.com/Leanplum/Leanplum-iOS-SDK.git', :tag => s.version.to_s }
   s.ios.deployment_target = '8.0'
-  s.tvos.deployment_target = '8.0'
   s.frameworks = 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.weak_frameworks = 'AdSupport', 'StoreKit'
   s.library = 'sqlite3'


### PR DESCRIPTION
We removed the TV OS parts of our code, since we weren't supporting that platform. However, it needs to also be removed from the Podspec, else the pod lint fails.