### PR TITLE
move bitcode flags to podfile from podspec

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,7 +8,7 @@ use_frameworks!
       config.build_settings['BITCODE_GENERATION_MODE'] = 'bitcode'
     end
   end
-end	end
+end
 
 target 'Leanplum-SDK_Example' do
   platform :ios, '8.0'

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,14 @@
-if ! ENV['LP_STATIC']
-  use_frameworks!
-end
+use_frameworks!
+  use_frameworks!	
+ 
+ post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'YES'
+      config.build_settings['BITCODE_GENERATION_MODE'] = 'bitcode'
+    end
+  end
+end	end
 
 target 'Leanplum-SDK_Example' do
   platform :ios, '8.0'

--- a/Leanplum-iOS-SDK.podspec
+++ b/Leanplum-iOS-SDK.podspec
@@ -27,7 +27,6 @@ Analytics.
   s.frameworks = 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.weak_frameworks = 'AdSupport', 'StoreKit'
   s.library = 'sqlite3'
-  s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC', 'BITCODE_GENERATION_MODE' => 'bitcode' }
   s.documentation_url = 'https://www.leanplum.com/docs#/docs'
   s.source_files = 'Leanplum-SDK/Classes/**/*'
   s.module_name = 'Leanplum'


### PR DESCRIPTION
For Carthage, our built framework needs to include bitcode. To enable this, we put the flags in the podspec. However, this forced everyone to use bitcode for all their pods, and became a problem for some customers. By moving the needed flags into the Podfile of our example, we still get the bitcode during compilation, but it is not forced by the Podspec on everyone.

https://leanplum.atlassian.net/browse/E2-1825