### PR TITLE
LP-10296 fix: iOS banner expand to fullscreen and unresponsive

### DIFF
--- a/Example/Leanplum-SDK.xcodeproj/project.pbxproj
+++ b/Example/Leanplum-SDK.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		653192A121517D4F00D7DDDC /* LPFeatureFlagManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 653192A021517D4F00D7DDDC /* LPFeatureFlagManagerTest.m */; };
+		65D4AB49224CA963009BA5F3 /* LPActionContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D4AB48224CA963009BA5F3 /* LPActionContextTest.m */; };
 		65E189C421643631005E6B93 /* LPRequestSenderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E189C321643631005E6B93 /* LPRequestSenderTest.m */; };
 		65E189C6216BDB82005E6B93 /* LPRequestFactoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E189C5216BDB82005E6B93 /* LPRequestFactoryTest.m */; };
 		65E53E982148786C00A05040 /* LPCountAggregatorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E53E962148786C00A05040 /* LPCountAggregatorTest.m */; };
@@ -190,6 +191,7 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		653192A021517D4F00D7DDDC /* LPFeatureFlagManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LPFeatureFlagManagerTest.m; sourceTree = "<group>"; };
+		65D4AB48224CA963009BA5F3 /* LPActionContextTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LPActionContextTest.m; sourceTree = "<group>"; };
 		65E189C321643631005E6B93 /* LPRequestSenderTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LPRequestSenderTest.m; sourceTree = "<group>"; };
 		65E189C5216BDB82005E6B93 /* LPRequestFactoryTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LPRequestFactoryTest.m; sourceTree = "<group>"; };
 		65E53E962148786C00A05040 /* LPCountAggregatorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPCountAggregatorTest.m; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				07E5C8821F052B7800A4B092 /* NewsfeedTest.m */,
 				07E5C8841F052B7800A4B092 /* Utilities */,
 				07E5C8891F052B7800A4B092 /* LPUtilsTest.m */,
+				65D4AB48224CA963009BA5F3 /* LPActionContextTest.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -749,6 +752,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65D4AB49224CA963009BA5F3 /* LPActionContextTest.m in Sources */,
 				07E5C8B31F052B7800A4B092 /* LPFileManagerTest.m in Sources */,
 				07E5C8B81F052B7800A4B092 /* MessagesTest.m in Sources */,
 				07E5C8BD1F052B7800A4B092 /* LeanplumHelper.m in Sources */,

--- a/Example/Tests/Classes/LPActionContextTest.m
+++ b/Example/Tests/Classes/LPActionContextTest.m
@@ -1,0 +1,9 @@
+//
+//  LPActionContextTest.m
+//  Leanplum-SDK_Tests
+//
+//  Created by Grace on 3/28/19.
+//  Copyright © 2019 Leanplum. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/Example/Tests/Classes/LPActionContextTest.m
+++ b/Example/Tests/Classes/LPActionContextTest.m
@@ -1,9 +1,100 @@
 //
 //  LPActionContextTest.m
-//  Leanplum-SDK_Tests
+//  Leanplum-SDK_Example
 //
 //  Created by Grace on 3/28/19.
 //  Copyright © 2019 Leanplum. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "LPActionContext.h"
+#import "LPVarCache.h"
+#import "LPConstants.h"
+
+/**
+ * Expose private class methods
+ */
+@interface LPActionContext(UnitTest)
+
+@property (nonatomic, strong) NSDictionary *args;
++ (LPActionContext *)actionContextWithName:(NSString *)name
+                                      args:(NSDictionary *)args
+                                 messageId:(NSString *)messageId;
+- (void)setProperArgs;
+
+@end
+
+@interface LPActionContextTest : XCTestCase
+
+@end
+
+@implementation LPActionContextTest
+
+- (void)setUp {
+    [super setUp];
+    
+    // initialize the var cache to be empty and have a dummy action
+    [[LPVarCache sharedCache] applyVariableDiffs:nil messages:nil updateRules:nil eventRules:nil variants:nil regions:nil variantDebugInfo:nil];
+    [[LPVarCache sharedCache] registerActionDefinition:@"action" ofKind:0 withArguments:@[] andOptions:@{}];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)test_setProperArgs_messageWithArgs {
+    // create context with current content version
+    LPActionContext *context = [LPActionContext
+                                actionContextWithName:@"action"
+                                args:nil
+                                messageId:@"1"];
+    
+    // apply diffs with new message to increase content version
+    NSMutableDictionary *message = [[NSMutableDictionary alloc] init];
+    message[LP_KEY_VARS] = @{@"key1": @"value1"};
+    NSDictionary *messages = @{@"1": message};
+    [[LPVarCache sharedCache] applyVariableDiffs:nil messages:messages updateRules:nil eventRules:nil variants:nil regions:nil variantDebugInfo:nil];
+    
+    // set args from the message in the cache
+    [context setProperArgs];
+    
+    XCTAssertEqualObjects([context args], @{@"key1": @"value1"});
+}
+
+- (void)test_setProperArgs_messageWithNilArgs {
+    // create context with current content version
+    LPActionContext *context = [LPActionContext
+                                actionContextWithName:@"action"
+                                args:@{}
+                                messageId:@"1"];
+    
+    // apply diffs with new message to increase content version
+    NSMutableDictionary *message = [[NSMutableDictionary alloc] init];
+    message[LP_KEY_VARS] = nil;
+    NSDictionary *messages = @{@"1": message};
+    [[LPVarCache sharedCache] applyVariableDiffs:nil messages:messages updateRules:nil eventRules:nil variants:nil regions:nil variantDebugInfo:nil];
+    
+    // set nil args from the message in the cache
+    [context setProperArgs];
+    
+    XCTAssertEqualObjects([context args], nil);
+}
+
+- (void)test_setProperArgs_noMessage {
+    // create context with current content version
+    LPActionContext *context = [LPActionContext
+                                actionContextWithName:@"action"
+                                args:@{}
+                                messageId:@"1"];
+    
+    // apply diffs with no message to increase content version
+    NSDictionary *messages = @{};
+    [[LPVarCache sharedCache] applyVariableDiffs:nil messages:messages updateRules:nil eventRules:nil variants:nil regions:nil variantDebugInfo:nil];
+    
+    // no message in cache, args should not be set
+    [context setProperArgs];
+    
+    XCTAssertEqualObjects([context args], @{});
+}
+
+@end

--- a/Leanplum-SDK/Classes/Features/Actions/LPActionContext.m
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionContext.m
@@ -188,9 +188,9 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
         if (parent) {
             _args = [parent getChildArgs:_key];
         } else if (_messageId) {
-            NSDictionary *cachedArgs = [LPVarCache sharedCache].messages[_messageId][LP_KEY_VARS];
-            if (cachedArgs) {
-                _args = cachedArgs;
+            NSDictionary *message = [LPVarCache sharedCache].messages[_messageId];
+            if (message) {
+                _args = message[LP_KEY_VARS];
             }
         }
     }

--- a/Leanplum-SDK/Classes/Features/Actions/LPActionContext.m
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionContext.m
@@ -188,7 +188,10 @@ typedef void (^LPFileCallback)(NSString* value, NSString *defaultValue);
         if (parent) {
             _args = [parent getChildArgs:_key];
         } else if (_messageId) {
-            _args = [LPVarCache sharedCache].messages[_messageId][LP_KEY_VARS];
+            NSDictionary *cachedArgs = [LPVarCache sharedCache].messages[_messageId][LP_KEY_VARS];
+            if (cachedArgs) {
+                _args = cachedArgs;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently when a message is shown on an app (the message is active and not closed), and the message is removed (or paused) on the dashboard, the message args become nil on the app when the user returns, causing UI issues and interaction issues. 

This fix prevents args from being set to nil when a message is present on an app but removed on the dashboard.

reference: https://leanplum.atlassian.net/browse/LP-10296