### PR TITLE
fix crash due to observers with blocks not being released.

### DIFF
--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -2804,4 +2804,8 @@ void LPLog(LPLogType type, NSString *format, ...) {
     }
     return nil;
 }
+
+- (void) dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 @end


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-10616](https://leanplum.atlassian.net/browse/LP-10616)
People Involved   | @aafrooze @e7mac @gg4race 

## Background
Multiple crashes were reported. All revolving around NSNotification. The suspect for these are the notification observers not being released.

## Implementation
Block based observers via the -[NSNotificationCenter addObserverForName:object:queue:usingBlock] method still need to be un-registered when no longer in use since the system still holds a strong reference to these observers.

## Testing steps
Its not possible to test these, since logging is not supported for deallocation block of memory or delegates.
