### PR TITLE
Removed compiler warnings

### DIFF
--- a/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionManager.h
@@ -62,11 +62,10 @@ typedef enum {
               fetchCompletionHandler:(LeanplumFetchCompletionBlock)completionHandler;
 - (void)didReceiveNotificationResponse:(UNNotificationResponse *)response
                  withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0));
-- (void)didReceiveLocalNotification:(UILocalNotification *)localNotification;
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
+- (void)didReceiveLocalNotification:(UILocalNotification *)localNotification;
 
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -463,12 +463,20 @@ typedef void (^LeanplumMessageDisplayedCallbackBlock)(LPMessageArchiveData *mess
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)token;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+#pragma clang diagnostic pop
 + (void)didReceiveRemoteNotification:(NSDictionary *)userInfo;
 + (void)didReceiveRemoteNotification:(NSDictionary *)userInfo
               fetchCompletionHandler:(LeanplumFetchCompletionBlock)completionHandler;
 + (void)didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)didReceiveLocalNotification:(UILocalNotification *)localNotification;
+#pragma clang diagnostic pop
 
 /**
  * Call this to handle custom actions for local notifications.


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | n/a
People Involved   | Only me

## Background
Compiler warnings continue to pop up in our logs.

## Implementation
Deprecation warnings are now ignored using `clang diagnostic`

## Testing steps
N/A

## Is this change backwards-compatible?
Yes.