### PR TITLE
E2-2047: update method to get push token for iOS 13

### DIFF
--- a/Example/Tests/Classes/LPActionManagerTest.m
+++ b/Example/Tests/Classes/LPActionManagerTest.m
@@ -312,10 +312,10 @@
 
 -(void)testHexadecimalStringFromData {
     LPActionManager *manager = [[LPActionManager alloc] init];
-    NSString *testString = @"testString";
+    NSString *testString = @"74657374537472696e67";
     NSData *data = [self hexDataFromString:testString];
     NSString *parsedString = [manager hexadecimalStringFromData:data];
-    XCTAssertEqual(testString, parsedString);
+    XCTAssertEqualObjects(testString, parsedString);
 }
 
 #pragma mark Helpers

--- a/Example/Tests/Classes/LPActionManagerTest.m
+++ b/Example/Tests/Classes/LPActionManagerTest.m
@@ -43,6 +43,7 @@
                           withAction:(NSString *)action
               fetchCompletionHandler:(LeanplumFetchCompletionBlock)completionHandler;
 - (void)leanplum_application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (NSString *)hexadecimalStringFromData:(NSData *)data;
 @end
 
 @interface LPActionManagerTest : XCTestCase
@@ -309,6 +310,14 @@
 
 }
 
+-(void)testHexadecimalStringFromData {
+    LPActionManager *manager = [[LPActionManager alloc] init];
+    NSString *testString = @"testString";
+    NSData *data = [self hexDataFromString:testString];
+    NSString *parsedString = [manager hexadecimalStringFromData:data];
+    XCTAssertEqual(testString, parsedString);
+}
+
 #pragma mark Helpers
 
 -(NSDictionary *)messageConfigInActivePeriod:(BOOL)inActivePeriod
@@ -324,4 +333,22 @@
                              };
     return config;
 }
+
+-(NSMutableData*)hexDataFromString:(NSString*)string {
+
+    NSMutableData *hexData= [[NSMutableData alloc] init];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [string length]/2; i++) {
+        byte_chars[0] = [string characterAtIndex:i*2];
+        byte_chars[1] = [string characterAtIndex:i*2+1];
+        whole_byte = strtol(byte_chars, NULL, 16);
+        [hexData appendBytes:&whole_byte length:1];
+    }
+    return hexData;
+}
+
+
+
 @end

--- a/Leanplum-SDK/Classes/Features/Actions/LPActionManager.m
+++ b/Leanplum-SDK/Classes/Features/Actions/LPActionManager.m
@@ -752,7 +752,7 @@ static dispatch_once_t leanplum_onceToken;
     }
 
     // Format push token.
-    NSString *formattedToken = [token description];
+    NSString *formattedToken = [self hexadecimalStringFromData:token];
     formattedToken = [[[formattedToken stringByReplacingOccurrencesOfString:@"<" withString:@""]
                        stringByReplacingOccurrencesOfString:@">" withString:@""]
                       stringByReplacingOccurrencesOfString:@" " withString:@""];
@@ -1318,6 +1318,22 @@ static dispatch_once_t leanplum_onceToken;
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         [defaults setBool:YES forKey:[NSString stringWithFormat:LEANPLUM_DEFAULTS_MESSAGE_MUTED_KEY, messageId]];
     }
+}
+
+#pragma mark - Helper methods
+- (NSString *)hexadecimalStringFromData:(NSData *)data
+{
+    NSUInteger dataLength = data.length;
+    if (dataLength == 0) {
+        return nil;
+    }
+
+    const unsigned char *dataBuffer = data.bytes;
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    return [hexString copy];
 }
 
 @end


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [E2-2047](https://leanplum.atlassian.net/browse/E2-2047)
People Involved   | @shivanshukumar , @hrishileanplum 

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
The gist of the problem is that the "description" method of NSData began returning different result in iOS 13 Beta 2 and newer. Many SDKs use this method to get the push token, but now it will no longer return the full push token.

## Implementation
I see that the Leanplum iOS SDK is affected based on the code here: https://github.com/Leanplum/Leanplum-iOS-SDK/blob/dd9f404aa07f479978289a5543a213d88700262c/Leanplum-SDK/Classes/Features/Actions/LPActionManager.m#L755

Instead of using `description`, get the hexString independently.

## Testing steps
Send remote push on iOS 13 device

## Is this change backwards-compatible?
Yes