### PR TITLE
Fix the old cached data based check

### DIFF
--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -1135,10 +1135,14 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
 
 - (void)updateNonWebPopupLayout:(int)statusBarHeight
 {
+    
+    LPActionContext *context = _contexts.lastObject;
+    BOOL isPushAskToAsk = [context.actionName isEqualToString:LPMT_PUSH_ASK_TO_ASK];
+    
     _popupBackground.frame = CGRectMake(0, 0, _popupView.frame.size.width, _popupView.frame.size.height);
     CGSize textSize = [self getTextSizeFromButton:_acceptButton];
 
-    if (_cancelButton) {
+    if (isPushAskToAsk) {
         CGSize cancelTextSize = [self getTextSizeFromButton:_cancelButton];
         textSize = CGSizeMake(MAX(textSize.width, cancelTextSize.width),
                               MAX(textSize.height, cancelTextSize.height));

--- a/Leanplum-SDK/Classes/LPMessageTemplates.m
+++ b/Leanplum-SDK/Classes/LPMessageTemplates.m
@@ -951,6 +951,8 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
                        [context.actionName isEqualToString:LPMT_HTML_NAME]);
     BOOL isWeb = [context.actionName isEqualToString:LPMT_WEB_INTERSTITIAL_NAME] ||
                  [context.actionName isEqualToString:LPMT_HTML_NAME];
+    
+    BOOL isPushAskToAsk = [context.actionName isEqualToString:LPMT_PUSH_ASK_TO_ASK];
 
     UIEdgeInsets safeAreaInsets = [self safeAreaInsets];
 
@@ -1002,7 +1004,7 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     }
 
     if (!isWeb) {
-        [self updateNonWebPopupLayout:statusBarHeight];
+        [self updateNonWebPopupLayout:statusBarHeight isPushAskToAsk:isPushAskToAsk];
         _overlayView.frame = CGRectMake(0, 0, screenWidth, screenHeight);
     }
     CGFloat leftSafeAreaX = safeAreaInsets.left;
@@ -1133,12 +1135,8 @@ static NSString *DEFAULTS_LEANPLUM_ENABLED_PUSH = @"__Leanplum_enabled_push";
     return textSize;
 }
 
-- (void)updateNonWebPopupLayout:(int)statusBarHeight
+- (void)updateNonWebPopupLayout:(int)statusBarHeight isPushAskToAsk:(BOOL)isPushAskToAsk
 {
-    
-    LPActionContext *context = _contexts.lastObject;
-    BOOL isPushAskToAsk = [context.actionName isEqualToString:LPMT_PUSH_ASK_TO_ASK];
-    
     _popupBackground.frame = CGRectMake(0, 0, _popupView.frame.size.width, _popupView.frame.size.height);
     CGSize textSize = [self getTextSizeFromButton:_acceptButton];
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11035](https://leanplum.atlassian.net/browse/LP-11035)
People Involved   | @colleague1, @colleague2

## Background
If you have a ASK based 2 button prompt displayed, the cancel button state was used for the subsequent popup layout displays. So, if there was a UI which was "push_Ask" false, without a cancel button. It still used the previous cancebutton value as a check, which was incorrect.


## Implementation
Get the latest data and not relay on incorrect previous state cached value.

## Testing steps

## Is this change backwards-compatible?
