### PR TITLE
[LP-11331] Fix Open action when Mute Inside App is used

### DIFF
--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -386,7 +386,7 @@
         }
     };
 
-    if (!userInfo[LP_KEY_PUSH_MUTE_IN_APP] && !userInfo[LP_KEY_PUSH_NO_ACTION_MUTE]) {
+    if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
         [Leanplum onStartIssued:^() {
             if ([self areActionsEmbedded:userInfo]) {
                 onContent();


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11331](https://leanplum.atlassian.net/browse/LP-11331)
People Involved   | 

## Background
[LP-11331](https://leanplum.atlassian.net/browse/LP-11331)
When the UNUserNotificationCenter delegate is used, the application is already in Active state when the `LPActionManager:didReceiveRemoteNotification` is called. This results in not handling the notification open action although it was received when the app was not on foreground (active).

## Implementation
Change the conditions so they do not prevent further handling the notification. This is based on the flow of handling the notification described below.

### When delegate is used
App is foreground
`willPresentNotification -> handleWillPresentNotification`
After that `didReceiveRemoteNotification` (handles mute inside app flag `LP_KEY_PUSH_MUTE_IN_APP`)

App is background/killed
when received: `didReceiveRemoteNotification` 
when opened:
`didReceiveNotificationResponse -> handleNotificationResponse -> maybePerformNotificationActions`

### When delegate is _not_ used
App is foreground
`didReceiveRemoteNotification`

App is background
when received: `didReceiveRemoteNotification -> handleNotification`
when opened:
`didReceiveRemoteNotification -> handleNotification -> maybePerformNotificationActions`

## Testing steps
Send a notification with an Open action different than the default one - Open app. Open URL can be used.

Mute inside app : true
1. When on foreground - nothing should be shown
2. (optional) App backgrounded when push received - open action is executed
3. (optional) App killed when push received - open action is executed

Mute inside app : false
1. When on foreground - confirm message is shown
2. (optional) App backgrounded when push received - open action is executed
3. (optional) App killed when push received - open action is executed

Both CC and Messages

## Is this change backwards-compatible?
Yes