### PR TITLE
Fix Integer Format Specifier Warning

### DIFF
--- a/Leanplum-SDK/Classes/Utilities/LPDatabase.m
+++ b/Leanplum-SDK/Classes/Utilities/LPDatabase.m
@@ -148,7 +148,7 @@ static BOOL willSendErrorLog;
                                    SQLITE_TRANSIENT);
         
         if (result != SQLITE_OK) {
-            NSString *message = [NSString stringWithFormat:@"SQLite fail to bind %@ to %ld", obj, idx+1];
+            NSString *message = [NSString stringWithFormat:@"SQLite fail to bind %@ to %lu", obj, (unsigned long)idx+1];
             [self handleSQLiteError:message errorResult:result query:query];
         }
     }];


### PR DESCRIPTION
## Background
Since NSUInteger is variable size based on architecture, it’s best to cast the variable to an explictly sized unsigned long and use the appropriate format specifier
## Implementation
N/A
## Testing steps
N/A
## Is this change backwards-compatible?
Yes