### PR TITLE
Fix Nullability Annotation Warnings

### DIFF
--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -329,8 +329,8 @@ NS_SWIFT_NAME(start(userId:completion:));
          userAttributes:(NSDictionary<NSString *, id> *)attributes
 NS_SWIFT_UNAVAILABLE("Use start(userId:attributes:completion:");
 
-+ (void)startWithUserId:(NSString *)userId
-         userAttributes:(NSDictionary<NSString *, id> *)attributes
++ (void)startWithUserId:(nullable NSString *)userId
+         userAttributes:(nullable NSDictionary<NSString *, id> *)attributes
         responseHandler:(nullable LeanplumStartBlock)startResponse
 NS_SWIFT_NAME(start(userId:attributes:completion:));
 /**@}*/


### PR DESCRIPTION
## Background
Two arguments in the `+ (void)startWithUserId:userAttributes:responseHandler:)` method are incorrectly annotated as `nonnull` (owing to `NS_ASSUME_NONNULL_BEGIN`) when they should be `nullable`.
This results in the following error in the following code in `Leanplum.m:348 :
> Null passed to a callee that requires a non-null argument
``` objective-c
+ (void)start
{
    [self startWithUserId:nil userAttributes:nil responseHandler:nil];
}
```
## Implementation
I have annotated the relevant arguments with `nullable` to silence this warning and more accurately reflect the fact that the method can accept `nil` arguments.

## Testing steps
N/A
## Is this change backwards-compatible?
Yes, making non null arguments nullable does not cause backwards compatibility issues, the reverse is not necessarily true.