### PR TITLE
Fix Catalyst Build Error

### DIFF
--- a/Leanplum-SDK/Classes/Managers/LPRevenueManager.m
+++ b/Leanplum-SDK/Classes/Managers/LPRevenueManager.m
@@ -137,10 +137,12 @@ void leanplum_finishTransaction(id self, SEL _cmd, SKPaymentTransaction *transac
         NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
         receipt = [NSData dataWithContentsOfURL:receiptURL];
     } else {
+#if !TARGET_OS_MACCATALYST
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         receipt = transaction.transactionReceipt;
 #pragma GCC diagnostic pop
+#endif
     }
 
     NSString *receiptBase64String = [LPUtils base64EncodedStringFromData:receipt];


### PR DESCRIPTION
##  Background
`SKPaymentTransaction.transactionReceipt` is marked as unavailable on Mac Catalyst, in favor of `NSBundle.mainBundle.appStoreReceiptURL`. This PR compiles out the old API when building for Catalyst.
<img width="1292" alt="Screen Shot 2020-06-25 at 12 51 10 PM" src="https://user-images.githubusercontent.com/2230175/85792545-8ea3f880-b6e8-11ea-8932-9b7cd5fe2682.png">

## Implementation
N/A
## Testing steps
N/A
## Is this change backwards-compatible?
Yes