### PR TITLE
prevent tracking open for remote notifications when app is active

### DIFF
--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -218,7 +218,14 @@
     if ([self isDuplicateNotification:userInfo]) {
         return;
     }
-
+    
+    if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
+        if (userInfo[LP_KEY_PUSH_NO_ACTION] ||
+            userInfo[LP_KEY_PUSH_NO_ACTION_MUTE]) {
+            return;
+        }
+    }
+    
     LPLog(LPInfo, @"Handling push notification");
     NSString *messageId = [[LPNotificationsManager shared] messageIdFromUserInfo:userInfo];
     NSString *actionName;


### PR DESCRIPTION
prevent tracking open for remote notifications when app is in foreground and there is no users action

What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11379](https://leanplum.atlassian.net/browse/LP-11379)

