### PR TITLE
[LP-11409] Add method to mark Inbox message as read

### DIFF
--- a/Example/Tests/Classes/LPInboxTest.m
+++ b/Example/Tests/Classes/LPInboxTest.m
@@ -26,13 +26,14 @@
 #import <XCTest/XCTest.h>
 #import <OHHTTPStubs/HTTPStubs.h>
 #import <OHHTTPStubs/HTTPStubsPathHelpers.h>
+#import <OCMock/OCMock.h>
 #import "LeanplumHelper.h"
 #import "LeanplumRequest+Categories.h"
 #import "LPNetworkEngine+Category.h"
 #import "Leanplum+Extensions.h"
 #import "LPFileManager.h"
 #import "LPActionManager.h"
-#import "LPConstants.h"
+#import "LPInbox.h"
 
 @interface LPInboxTest : XCTestCase
 
@@ -52,6 +53,8 @@
     [super tearDown];
     // Clean up after every test.
     [LeanplumHelper clean_up];
+    // Clean up saved requests.
+    [LPEventDataManager deleteEventsWithLimit:[LPEventDataManager count]];
     [HTTPStubs removeAllStubs];
 }
 
@@ -334,6 +337,143 @@
 
     [HTTPStubs removeStub:stub];
     [[Leanplum inbox] reset];
+}
+
+/**
+ * Tests inbox message [markAsRead]
+ * Message is marked as read
+ * markNewsfeedMessageAsRead  API action is called
+ */
+-(void)test_markAsRead
+{
+    dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+    [self loadInbox:^{
+        // Wait for callback
+        dispatch_semaphore_signal(semaphor);
+    }];
+    
+    dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
+    
+    XCTAssertEqual(2, [[Leanplum inbox] unreadCount]);
+    LPInboxMessage *msg = [[Leanplum inbox] allMessages][0];
+    
+    semaphor = dispatch_semaphore_create(0);
+    [LeanplumRequest validate_request:^BOOL(NSString *method, NSString  *apiMethod,
+                                        NSDictionary  *params) {
+        XCTAssertEqualObjects(apiMethod, @"markNewsfeedMessageAsRead");
+        dispatch_semaphore_signal(semaphor);
+        return YES;
+    }];
+
+    [msg markAsRead];
+
+    XCTAssertTrue([msg isRead]);
+    XCTAssertEqual(1, [[Leanplum inbox] unreadCount]);
+    
+    long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
+    XCTAssertTrue(timedOut == 0);
+}
+
+/**
+ * Tests inbox message [markAsRead] does not run the message open action
+ */
+-(void)test_markAsRead_not_run_action
+{
+    dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+    [self loadInbox:^{
+        // Wait for callback
+        dispatch_semaphore_signal(semaphor);
+    }];
+    
+    LPInboxMessage *msg = [[Leanplum inbox] allMessages][0];
+    id mock = OCMPartialMock(msg.context);
+    
+    OCMReject([mock runTrackedActionNamed:[OCMArg any]]);
+    [msg markAsRead];
+    XCTAssertTrue([msg isRead]);
+}
+
+/**
+ * Tests inbox message [read] does run the message open action and marks it as read
+ */
+-(void)test_read_runs_action
+{
+    dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+    [self loadInbox:^{
+        // Wait for callback
+        dispatch_semaphore_signal(semaphor);
+    }];
+    
+    LPInboxMessage *msg = [[Leanplum inbox] allMessages][0];
+    id mock = OCMPartialMock(msg.context);
+    [msg read];
+    
+    OCMVerify([mock runTrackedActionNamed:[OCMArg any]]);
+    XCTAssertTrue([msg isRead]);
+}
+
+/**
+ * Tests inbox message [read]
+ * Message is marked as read
+ * markNewsfeedMessageAsRead  API action is called
+ * Message open action is run [context runTrackedActionNamed:]
+*/
+-(void)test_read
+{
+    dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+    [self loadInbox:^{
+        // Wait for callback
+        dispatch_semaphore_signal(semaphor);
+    }];
+    dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
+    
+    XCTAssertEqual(2, [[Leanplum inbox] unreadCount]);
+    LPInboxMessage *msg = [[Leanplum inbox] allMessages][0];
+    
+    semaphor = dispatch_semaphore_create(0);
+    [LeanplumRequest validate_request:^BOOL(NSString *method, NSString  *apiMethod,
+                                        NSDictionary  *params) {
+        XCTAssertEqualObjects(apiMethod, @"markNewsfeedMessageAsRead");
+        dispatch_semaphore_signal(semaphor);
+        return YES;
+    }];
+    
+    id mock = OCMPartialMock(msg.context);
+    
+    [msg read];
+    OCMVerify([mock runTrackedActionNamed:[OCMArg any]]);
+
+    XCTAssertTrue([msg isRead]);
+    XCTAssertEqual(1, [[Leanplum inbox] unreadCount]);
+    
+    long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
+    XCTAssertTrue(timedOut == 0);
+}
+
+-(void)loadInbox:(void (^)(void))finishBlock
+{
+    // Do not need to fetch images
+    // Prefetching will trigger downloadFile requests
+    [[Leanplum inbox] disableImagePrefetching];
+    // Ensure errors are thrown
+    [LeanplumHelper mockThrowErrorToThrow];
+    
+    id<HTTPStubsDescriptor> getNewsfeedMessagesStub = [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+        return [request.URL.host isEqualToString:API_HOST];
+    } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest *request) {
+        NSString *response_file = OHPathForFile(@"newsfeed_response.json", self.class);
+        return [HTTPStubsResponse responseWithFileAtPath:response_file
+                                                statusCode:200
+                                                   headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    [[Leanplum inbox] onChanged:^{
+        [HTTPStubs removeStub:getNewsfeedMessagesStub];
+        finishBlock();
+    }];
+
+    [LeanplumHelper setup_development_test];
+    [[Leanplum inbox] downloadMessages];
 }
 
 @end

--- a/Example/Tests/Classes/Utilities/LeanplumHelper.m
+++ b/Example/Tests/Classes/Utilities/LeanplumHelper.m
@@ -183,10 +183,21 @@ static BOOL swizzled = NO;
     @throw([NSException exceptionWithName:err reason:nil userInfo:nil]);
 }
 
++ (void) handleException:(NSException *) ex
+{
+    [LeanplumHelper setLastErrorMessage:[ex name]];
+    @throw(ex);
+}
+
 + (void) mockThrowErrorToThrow
 {
     id mockLeanplumClass = OCMClassMock([Leanplum class]);
     [OCMStub(ClassMethod([mockLeanplumClass throwError:[OCMArg any]])) andCall:@selector(throwError:) onObject:self];
+
+    // Cannot mock leanplumInternalError(NSException *e) since it is a function
+    // Mocking [LPUtils handleException:e] which is used inside leanplumInternalError first
+    id mockLPUtilsClass = OCMClassMock([LPUtils class]);
+    [OCMStub(ClassMethod([mockLPUtilsClass handleException:[OCMArg any]])) andCall:@selector(handleException:) onObject:self];
 }
 
 @end

--- a/Leanplum-SDK/Classes/Features/Inbox/LPInbox.m
+++ b/Leanplum-SDK/Classes/Features/Inbox/LPInbox.m
@@ -179,7 +179,7 @@ static NSObject *updatingLock;
     return nil;
 }
 
-- (void)read
+- (void)markAsRead
 {
     if (![self isRead]) {
         [self setIsRead:YES];
@@ -196,6 +196,11 @@ static NSObject *updatingLock;
         [[LPRequestSender sharedInstance] send:request];
         LP_END_TRY
     }
+}
+
+- (void)read
+{
+    [self markAsRead];
     
     LP_TRY
     [[self context] runTrackedActionNamed:LP_VALUE_DEFAULT_PUSH_ACTION];

--- a/Leanplum-SDK/Classes/LPInbox.h
+++ b/Leanplum-SDK/Classes/LPInbox.h
@@ -84,6 +84,11 @@ NS_SWIFT_NAME(LeanplumInbox.Message)
 @property (assign, nonatomic, readonly) BOOL isRead;
 
 /**
+ * Mark the inbox message as read without invoking its open action.
+ */
+- (void)markAsRead;
+
+/**
  * Read the inbox message, marking it as read and invoking its open action.
  */
 - (void)read;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11409](https://leanplum.atlassian.net/browse/LP-11409)

## Background
Add an option to mark an inbox message as read without running the message open action.

## Implementation
Move the logic for marking a message as read and sending a request to a separate method.

## Testing steps
Added separate unit tests for both `read` and `markAsRead` methods of `LPInbox`.

## Is this change backwards-compatible?
Yes
