### PR TITLE
[SDK-41] register for push

### DIFF
--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.h
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.h
@@ -7,12 +7,11 @@
 //
 
 #import "LPMessageTemplateProtocol.h"
+#import "LPPushMessageTemplate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LPPushAskToAskMessageTemplate : NSObject <LPMessageTemplateProtocol>
-
-- (void)enableSystemPush;
+@interface LPPushAskToAskMessageTemplate : LPPushMessageTemplate <LPMessageTemplateProtocol>
 
 @end
 

--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.m
@@ -7,7 +7,7 @@
 //
 
 #import "LPPushAskToAskMessageTemplate.h"
-#import "LPActionManager.h"
+#import "LPPushMessageTemplate.h"
 
 @implementation LPPushAskToAskMessageTemplate
 
@@ -56,20 +56,12 @@
         @try {            
             LPPushAskToAskMessageTemplate *template = [[LPPushAskToAskMessageTemplate alloc] init];
             template.context = context;
-
-            if ([Leanplum isPreLeanplumInstall]) {
-                NSLog(@"Leanplum: 'Ask to ask' conservatively falls back to just 'ask' for pre-Leanplum installs");
-                [template showPushMessage];
-                return NO;
-            } else if ([template isPushEnabled]) {
-                NSLog(@"Leanplum: Pushes already enabled");
-                return NO;
-            } else if ([template hasDisabledAskToAsk]) {
-                NSLog(@"Leanplum: Already asked to push");
-                return NO;
-            } else {
+            
+            if ([template shouldShowPushMessage]) {
                 [template showPrePushMessage];
                 return YES;
+            } else {
+                return NO;
             }
         } @catch (NSException *exception) {
             NSLog(@"Leanplum: Error in pushAskToAsk: %@\n%@", exception, [exception callStackSymbols]);
@@ -86,14 +78,9 @@
     __strong __typeof__(self) strongSelf = self;
     viewController.pushAskToAskCompletionBlock = ^{
         __typeof__(self) weakSelf = strongSelf;
-        [weakSelf enableSystemPush];
+        [weakSelf showNativePushPrompt];
     };
     return viewController;
-}
-
--(void)showPushMessage
-{
-    [self enableSystemPush];
 }
 
 -(void)showPrePushMessage
@@ -101,21 +88,6 @@
     UIViewController *viewController = [self viewControllerWithContext:self.context];
 
     [LPMessageTemplateUtilities presentOverVisible:viewController];
-}
-
-- (BOOL)isPushEnabled
-{
-    return [[LPPushNotificationsManager sharedManager] isPushEnabled];
-}
-
-- (void)enableSystemPush
-{
-    [[LPPushNotificationsManager sharedManager] enableSystemPush];
-}
-
-- (BOOL)hasDisabledAskToAsk
-{
-    return [[LPPushNotificationsManager sharedManager] hasDisabledAskToAsk];
 }
 
 @end

--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.h
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.h
@@ -1,0 +1,24 @@
+//
+//  LPPushMessageTemplate.h
+//  Leanplum-iOS-SDK
+//
+//  Created by Nikola Zagorchev on 19.08.20.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LPPushMessageTemplate : NSObject
+
+- (BOOL)shouldShowPushMessage;
+
+- (void)showNativePushPrompt;
+
+- (BOOL)isPushEnabled;
+
+- (BOOL)hasDisabledAskToAsk;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.m
@@ -1,0 +1,46 @@
+//
+//  LPPushMessageTemplate.m
+//  Leanplum-iOS-SDK
+//
+//  Created by Nikola Zagorchev on 19.08.20.
+//
+
+#import "LPPushMessageTemplate.h"
+#import "LPActionManager.h"
+
+@implementation LPPushMessageTemplate
+
+// TODO: Use the new logging when it is merged
+-(BOOL)shouldShowPushMessage
+{
+    if ([Leanplum isPreLeanplumInstall]) {
+        NSLog(@"Leanplum: 'Ask to ask' conservatively falls back to just 'ask' for pre-Leanplum installs");
+        [self showNativePushPrompt];
+        return NO;
+    } else if ([self isPushEnabled]) {
+        NSLog(@"Leanplum: Pushes already enabled");
+        return NO;
+    } else if ([self hasDisabledAskToAsk]) {
+        NSLog(@"Leanplum: Already asked to push");
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
+-(void)showNativePushPrompt
+{
+    [[LPPushNotificationsManager sharedManager] enableSystemPush];
+}
+
+- (BOOL)isPushEnabled
+{
+    return [[LPPushNotificationsManager sharedManager] isPushEnabled];
+}
+
+- (BOOL)hasDisabledAskToAsk
+{
+    return [[LPPushNotificationsManager sharedManager] hasDisabledAskToAsk];
+}
+
+@end

--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushMessageTemplate.m
@@ -7,21 +7,21 @@
 
 #import "LPPushMessageTemplate.h"
 #import "LPActionManager.h"
+#import "LPLogManager.h"
 
 @implementation LPPushMessageTemplate
 
-// TODO: Use the new logging when it is merged
 -(BOOL)shouldShowPushMessage
 {
     if ([Leanplum isPreLeanplumInstall]) {
-        NSLog(@"Leanplum: 'Ask to ask' conservatively falls back to just 'ask' for pre-Leanplum installs");
+        LPLog(LPDebug, @"'Ask to ask' conservatively falls back to just 'ask' for pre-Leanplum installs");
         [self showNativePushPrompt];
         return NO;
     } else if ([self isPushEnabled]) {
-        NSLog(@"Leanplum: Pushes already enabled");
+        LPLog(LPDebug, @"Pushes already enabled");
         return NO;
     } else if ([self hasDisabledAskToAsk]) {
-        NSLog(@"Leanplum: Already asked to push");
+        LPLog(LPDebug, @" Already asked to push");
         return NO;
     } else {
         return YES;

--- a/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.h
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.h
@@ -7,10 +7,11 @@
 //
 
 #import "LPMessageTemplateProtocol.h"
+#import "LPPushMessageTemplate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LPRegisterForPushMessageTemplate : NSObject <LPMessageTemplateProtocol>
+@interface LPRegisterForPushMessageTemplate : LPPushMessageTemplate <LPMessageTemplateProtocol>
 
 @end
 

--- a/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.m
@@ -7,7 +7,7 @@
 //
 
 #import "LPRegisterForPushMessageTemplate.h"
-#import "LPPushAskToAskMessageTemplate.h"
+#import "LPPushMessageTemplate.h"
 
 @implementation LPRegisterForPushMessageTemplate
 
@@ -18,13 +18,34 @@
              withArguments:@[]
              withResponder:^BOOL(LPActionContext *context) {
 
-        // TODO: when push check is moved away from templates, refactor to call it.
-        LPPushAskToAskMessageTemplate* template = [[LPPushAskToAskMessageTemplate alloc] init];
-        template.context = context;
-
-        [template enableSystemPush];
+        LPRegisterForPushMessageTemplate *template = [[LPRegisterForPushMessageTemplate alloc] init];
+        
+        if ([template shouldShowPushMessage]) {
+            // Try showing the native prompt
+            // iOS can prevent showing the dialog if recently asked
+            [template showNativePushPrompt];
+            // Will count View event
+            return YES;
+        } else {
+            return NO;
+        }
+        
         return YES;
     }];
+}
+
+/**
+ * If push notifications are not enabled returns true.
+ * Does not perform other checks as Push Ask to Ask to enable re-triggering of native prompt
+ */
+-(BOOL)shouldShowPushMessage
+{
+    if ([self isPushEnabled]) {
+        NSLog(@"Leanplum: Pushes already enabled");
+        return NO;
+    } else {
+        return YES;
+    }
 }
 
 @end

--- a/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPRegisterForPushMessageTemplate.m
@@ -21,8 +21,6 @@
         LPRegisterForPushMessageTemplate *template = [[LPRegisterForPushMessageTemplate alloc] init];
         
         if ([template shouldShowPushMessage]) {
-            // Try showing the native prompt
-            // iOS can prevent showing the dialog if recently asked
             [template showNativePushPrompt];
             // Will count View event
             return YES;
@@ -32,20 +30,6 @@
         
         return YES;
     }];
-}
-
-/**
- * If push notifications are not enabled returns true.
- * Does not perform other checks as Push Ask to Ask to enable re-triggering of native prompt
- */
--(BOOL)shouldShowPushMessage
-{
-    if ([self isPushEnabled]) {
-        NSLog(@"Leanplum: Pushes already enabled");
-        return NO;
-    } else {
-        return YES;
-    }
 }
 
 @end


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-41](https://leanplum.atlassian.net/browse/SDK-41)

## Background
View events are tracked for Register for Push action even if the prompt is not shown.

## Implementation
Combine the logic for checking and calling the native prompt under an LPPushMessageTemplate. AskToAsk and RegisterForPush inherit from that one.

## Testing steps

## Is this change backwards-compatible?
Yes