### PR TITLE
Switch device ID and Ads pre-permission

### DIFF
--- a/Example/Tests/Classes/Extensions/LPRequestSender+Categories.h
+++ b/Example/Tests/Classes/Extensions/LPRequestSender+Categories.h
@@ -28,11 +28,16 @@
 @interface LPRequestSender(MethodSwizzling)
 
 @property (assign) BOOL (^requestCallback)(NSString *method, NSString *apiMethod, NSDictionary *params);
+@property (assign) void (^createArgsCallback)(NSDictionary *args);
 
 - (void)setRequestCallback:(BOOL (^)(NSString *, NSString *, NSDictionary *))requestCallback;
 - (BOOL (^)(NSString *, NSString *, NSDictionary *))requestCallback;
 
+- (void)setCreateArgsCallback:(void (^)(NSDictionary *))createArgsCallback;
+- (void (^)(NSDictionary *))createArgsCallback;
+
 + (void)validate_request:(BOOL (^)(NSString *, NSString *, NSDictionary *))callback;
++ (void)validate_request_args_dictionary:(void (^)(NSDictionary *))callback;
 + (void)swizzle_methods;
 + (void)reset;
 

--- a/Example/Tests/Classes/Extensions/Leanplum+Extensions.h
+++ b/Example/Tests/Classes/Extensions/Leanplum+Extensions.h
@@ -40,7 +40,7 @@
 
 + (void)triggerAction:(LPActionContext *)context handledBlock:(LeanplumHandledBlock)handledBlock;
 
-+ (void)switchDevice:(NSString *)deviceId;
++ (void)setDeviceIdInternal:(NSString *)deviceId;
 
 @end
 

--- a/Example/Tests/Classes/Extensions/Leanplum+Extensions.h
+++ b/Example/Tests/Classes/Extensions/Leanplum+Extensions.h
@@ -40,6 +40,8 @@
 
 + (void)triggerAction:(LPActionContext *)context handledBlock:(LeanplumHandledBlock)handledBlock;
 
++ (void)switchDevice:(NSString *)deviceId;
+
 @end
 
 @interface LPPushNotificationsHandler(UnitTest)

--- a/Example/Tests/Classes/LPCountAggregatorTest.m
+++ b/Example/Tests/Classes/LPCountAggregatorTest.m
@@ -27,7 +27,6 @@
 #import <OCMock/OCMock.h>
 #import "LPCountAggregator.h"
 #import "LPConstants.h"
-#import "LPRequest.h"
 #import <Leanplum/LPRequestSender.h>
 #import <Leanplum/LPNetworkConstants.h>
 #import "LeanplumHelper.h"

--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -1010,6 +1010,7 @@
     long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
     XCTAssertTrue(timedOut == 0);
     XCTAssertTrue([[LPAPIConfig sharedConfig].deviceId isEqualToString:deviceId]);
+    XCTAssertTrue([[LPInternalState sharedState].deviceId isEqualToString:deviceId]);
 }
 
 /**

--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -925,6 +925,9 @@
     XCTAssertTrue([Leanplum hasStarted]);
 }
 
+/**
+ * Tests setting the device id before Leanplum start
+ */
 - (void) test_set_device_id
 {
     id mockLeanplum = OCMClassMock([Leanplum class]);
@@ -963,6 +966,9 @@
     XCTAssertTrue([Leanplum hasStarted]);
 }
 
+/**
+ * Tests setting the device id after Leanplum has started (uses setDeviceIdInternal)
+ */
 - (void) test_set_device_id_after_start
 {
     id mockLeanplum = OCMClassMock([Leanplum class]);

--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -1004,7 +1004,6 @@
     long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
     XCTAssertTrue(timedOut == 0);
     XCTAssertTrue([[LPAPIConfig sharedConfig].deviceId isEqualToString:deviceId]);
-    XCTAssertTrue([[LPInternalState sharedState].deviceId isEqualToString:deviceId]);
 }
 
 /**

--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -1010,7 +1010,6 @@
     long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
     XCTAssertTrue(timedOut == 0);
     XCTAssertTrue([[LPAPIConfig sharedConfig].deviceId isEqualToString:deviceId]);
-    XCTAssertTrue([[LPInternalState sharedState].deviceId isEqualToString:deviceId]);
 }
 
 /**

--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -928,7 +928,7 @@
 - (void) test_set_device_id
 {
     id mockLeanplum = OCMClassMock([Leanplum class]);
-    OCMReject([mockLeanplum switchDevice:[OCMArg any]]);
+    OCMReject([mockLeanplum setDeviceIdInternal:[OCMArg any]]);
     
     NSString *deviceId = @"testDeviceId";
     [Leanplum setDeviceId:deviceId];
@@ -999,7 +999,7 @@
     [Leanplum onStartResponse:^(BOOL success) {
         XCTAssertTrue(success);
         [Leanplum setDeviceId:deviceId];
-        OCMVerify([mockLeanplum switchDevice:[OCMArg any]]);
+        OCMVerify([mockLeanplum setDeviceIdInternal:[OCMArg any]]);
     }];
     long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
     XCTAssertTrue(timedOut == 0);

--- a/Leanplum-SDK/Classes/Internal/LPInternalState.h
+++ b/Leanplum-SDK/Classes/Internal/LPInternalState.h
@@ -18,7 +18,6 @@
 @property(strong, nonatomic) LPRegisterDevice *registration;
 @property(assign, nonatomic) BOOL calledStart, hasStarted, hasStartedAndRegisteredAsDeveloper, startSuccessful, issuedStart, stripViewControllerFromState;
 @property(strong, nonatomic) LPActionManager *actionManager;
-@property(strong, nonatomic) NSString *deviceId;
 @property(strong, nonatomic) NSString *appVersion;
 @property(strong, nonatomic) NSMutableArray *userAttributeChanges;
 @property(assign, nonatomic) BOOL isScreenTrackingEnabled;

--- a/Leanplum-SDK/Classes/Internal/LPInternalState.m
+++ b/Leanplum-SDK/Classes/Internal/LPInternalState.m
@@ -37,7 +37,6 @@
         _hasStartedAndRegisteredAsDeveloper = NO;
         _startSuccessful = NO;
         _actionManager = nil;
-        _deviceId = nil;
         _userAttributeChanges = [NSMutableArray array];
         _stripViewControllerFromState = NO;
         _isScreenTrackingEnabled = NO;

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -383,7 +383,43 @@ void leanplumExceptionHandler(NSException *exception);
     }
     LP_TRY
     [LPInternalState sharedState].deviceId = deviceId;
+    // If Leanplum start has been called already, changing the deviceId results in a new device
+    // Ensure the id is updated and the new device has all attributes set
+    if ([LPInternalState sharedState].hasStarted) {
+        [self setDeviceIdInternal:deviceId];
+    }
     LP_END_TRY
+}
+
++(void)setDeviceIdInternal:(NSString *)deviceId
+{
+    UIDevice *device = [UIDevice currentDevice];
+    NSString *versionName = [self appVersion];
+    NSMutableDictionary *params = [@{
+        LP_PARAM_VERSION_NAME: versionName,
+        LP_PARAM_DEVICE_NAME: device.name,
+        LP_PARAM_DEVICE_MODEL: [self platform],
+        LP_PARAM_DEVICE_SYSTEM_NAME: device.systemName,
+        LP_PARAM_DEVICE_SYSTEM_VERSION: device.systemVersion,
+        LP_PARAM_DEVICE_ID: deviceId
+    } mutableCopy];
+    
+    NSString *pushToken = [[LPPushNotificationsManager sharedManager] pushToken];
+    if (pushToken) {
+        params[LP_PARAM_DEVICE_PUSH_TOKEN] = pushToken;
+    }
+
+    [params addEntriesFromDictionary:[[[LPPushNotificationsManager sharedManager] handler] currentUserNotificationSettings]];
+    
+    // Change the LPAPIConfig after getting the push token and settings
+    // The LPAPIConfig value is used in retrieving them
+    [[LPAPIConfig sharedConfig] setDeviceId:deviceId];
+    [[LPVarCache sharedCache] saveDiffs];
+    // Update the token and settings now that the key is different
+    [[LPPushNotificationsManager sharedManager] updatePushToken:pushToken];
+    
+    LPRequest *request = [LPRequestFactory setDeviceAttributesWithParams:params];
+    [[LPRequestSender sharedInstance] send:request];
 }
 
 + (void)syncResourcesAsync:(BOOL)async
@@ -847,11 +883,7 @@ void leanplumExceptionHandler(NSException *exception);
     [[LPAPIConfig sharedConfig] setUserId:userId];
 
     // Setup parameters.
-    NSString *versionName = [LPInternalState sharedState].appVersion;
-    if (!versionName) {
-        versionName = [[[NSBundle mainBundle] infoDictionary]
-                       objectForKey:@"CFBundleVersion"];
-    }
+    NSString *versionName = [self appVersion];
     UIDevice *device = [UIDevice currentDevice];
     NSLocale *currentLocale = [NSLocale currentLocale];
     NSString *currentLocaleString = [NSString stringWithFormat:@"%@_%@",
@@ -2535,6 +2567,16 @@ void leanplumExceptionHandler(NSException *exception)
             boolForKey:LEANPLUM_DEFAULTS_PRE_LEANPLUM_INSTALL_KEY];
     LP_END_TRY
     return NO;
+}
+
++ (NSString *)appVersion
+{
+    NSString *versionName = [LPInternalState sharedState].appVersion;
+    if (!versionName) {
+        versionName = [[[NSBundle mainBundle] infoDictionary]
+                       objectForKey:@"CFBundleVersion"];
+    }
+    return versionName;
 }
 
 + (NSString *)deviceId

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -382,12 +382,11 @@ void leanplumExceptionHandler(NSException *exception);
         return;
     }
     LP_TRY
+    [LPInternalState sharedState].deviceId = deviceId;
     // If Leanplum start has been called already, changing the deviceId results in a new device
     // Ensure the id is updated and the new device has all attributes set
     if ([LPInternalState sharedState].hasStarted) {
         [self setDeviceIdInternal:deviceId];
-    } else {
-        [[LPAPIConfig sharedConfig] setDeviceId:deviceId];
     }
     LP_END_TRY
 }
@@ -416,11 +415,8 @@ void leanplumExceptionHandler(NSException *exception);
     // The LPAPIConfig value is used in retrieving them
     [[LPAPIConfig sharedConfig] setDeviceId:deviceId];
     [[LPVarCache sharedCache] saveDiffs];
-    
     // Update the token and settings now that the key is different
     [[LPPushNotificationsManager sharedManager] updatePushToken:pushToken];
-    UIUserNotificationSettings *settings = [[UIApplication sharedApplication] currentUserNotificationSettings];
-    [[[LPPushNotificationsManager sharedManager] handler] updateUserNotificationSettings:settings];
     
     LPRequest *request = [LPRequestFactory setDeviceAttributesWithParams:params];
     [[LPRequestSender sharedInstance] send:request];
@@ -866,7 +862,11 @@ void leanplumExceptionHandler(NSException *exception);
         deviceId = nil;
     }
     if (!deviceId) {
-        deviceId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        if (state.deviceId) {
+            deviceId = state.deviceId;
+        } else {
+            deviceId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        }
         if (!deviceId) {
             deviceId = [[UIDevice currentDevice] leanplum_uniqueGlobalDeviceIdentifier];
         }

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -784,6 +784,11 @@ NS_SWIFT_UNAVAILABLE("use forceContentUpdate(completion:)");
 + (BOOL)isPreLeanplumInstall;
 
 /**
+ * Returns the app version used by Leanplum.
+ */
++ (nullable NSString *)appVersion;
+
+/**
  * Returns the deviceId in the current Leanplum session. This should only be called after
  * [Leanplum start].
  */

--- a/Leanplum-SDK/Classes/Managers/LPLogManager.m
+++ b/Leanplum-SDK/Classes/Managers/LPLogManager.m
@@ -77,8 +77,7 @@ static LPLogLevel logLevel = Info;
             @throw e;
         }
     }
-    NSString *versionName = [[[NSBundle mainBundle] infoDictionary]
-                             objectForKey:@"CFBundleVersion"];
+    NSString *versionName = [Leanplum appVersion];
     if (!versionName) {
         versionName = @"";
     }

--- a/Leanplum-SDK/Classes/Managers/Networking/LPFileTransferManager.m
+++ b/Leanplum-SDK/Classes/Managers/Networking/LPFileTransferManager.m
@@ -71,7 +71,7 @@
 
         if (_engine == nil) {
             if (!_requestHeaders) {
-                _requestHeaders = [LPUtils createHeaders];
+                _requestHeaders = [LPRequestSender createHeaders];
             }
             _engine = [LPNetworkFactory engineWithHostName:[LPConstantsState sharedState].apiHostName
                                         customHeaderFields:_requestHeaders];

--- a/Leanplum-SDK/Classes/Managers/Networking/LPRequestSender.h
+++ b/Leanplum-SDK/Classes/Managers/Networking/LPRequestSender.h
@@ -31,6 +31,13 @@
 
 + (instancetype)sharedInstance;
 
+/**
+ * Create Request Headers for network call
+ */
++ (NSDictionary *)createHeaders;
+
++ (NSDictionary *)notificationSettingsToRequestParams:(NSDictionary *)settings;
+
 - (NSMutableDictionary *)createArgsDictionaryForRequest:(LPRequest *)request;
 - (void)attachApiKeys:(NSMutableDictionary *)dict;
 

--- a/Leanplum-SDK/Classes/MessageTemplates/LPCenterPopupMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPCenterPopupMessageTemplate.m
@@ -53,6 +53,7 @@
     LPPopupViewController *viewController = [LPPopupViewController instantiateFromStoryboard];
     viewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
     viewController.context = context;
+    viewController.shouldShowCancelButton = NO;
     return viewController;
 }
 

--- a/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/LPPushAskToAskMessageTemplate.m
@@ -74,8 +74,9 @@
     LPPopupViewController *viewController = [LPPopupViewController instantiateFromStoryboard];
     viewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
     viewController.context = context;
+    viewController.shouldShowCancelButton = YES;
     __strong __typeof__(self) strongSelf = self;
-    viewController.pushAskToAskCompletionBlock = ^{
+    viewController.acceptCompletionBlock = ^{
         __typeof__(self) weakSelf = strongSelf;
         [weakSelf showNativePushPrompt];
     };

--- a/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.h
+++ b/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.h
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface LPPopupViewController : UIViewController
 
 @property (strong, nonatomic) LPActionContext *context;
-@property(copy) void (^pushAskToAskCompletionBlock)(void);
+@property (copy) void (^acceptCompletionBlock)(void);
+@property BOOL shouldShowCancelButton;
 
 @property (weak, nonatomic) IBOutlet UIView *containerView;
 @property (weak, nonatomic) IBOutlet UIButton *dismissButton;

--- a/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.m
@@ -38,8 +38,6 @@
         return;
     }
 
-    NSString *actionName = [self.context actionName];
-
     // width and height constraints
     self.widthConstraint.constant = [[self.context numberNamed:LPMT_ARG_LAYOUT_WIDTH] doubleValue];
     self.heightConstraint.constant = [[self.context numberNamed:LPMT_ARG_LAYOUT_HEIGHT] doubleValue];

--- a/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPPopupViewController.m
@@ -77,7 +77,7 @@
     self.backgroundImageView.layer.masksToBounds = YES;
 
     // if its pre push permission dialog, show cancel button
-    if ([actionName isEqualToString:LPMT_PUSH_ASK_TO_ASK]) {
+    if (self.shouldShowCancelButton) {
         [self.cancelButton setHidden:NO];
         [self.dismissButton setHidden:YES];
 
@@ -99,8 +99,8 @@
 
 - (IBAction)didTapAcceptButton:(id)sender
 {
-    if([[self.context actionName] isEqualToString:LPMT_PUSH_ASK_TO_ASK]) {
-        self.pushAskToAskCompletionBlock();
+    if(self.acceptCompletionBlock != nil) {
+        self.acceptCompletionBlock();
     }
     [self.context runTrackedActionNamed:LPMT_ARG_ACCEPT_ACTION];
     [self dismiss:YES];

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) LeanplumShouldHandleNotificationBlock shouldHandleNotification;
 @property (nonatomic, assign) BOOL appWasActivatedByReceivingPushNotification;
+@property (nonatomic, readonly) NSDictionary *currentUserNotificationSettings;
 
 - (void)didReceiveRemoteNotification:(NSDictionary *)userInfo;
 - (void)didReceiveRemoteNotification:(NSDictionary *)userInfo

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
@@ -38,7 +38,6 @@ withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0))
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
-- (BOOL)updateUserNotificationSettings:(UIUserNotificationSettings *)newNotificationSettings;
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;
 #pragma clang diagnostic pop
 

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
@@ -38,6 +38,7 @@ withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0))
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+- (BOOL)updateUserNotificationSettings:(UIUserNotificationSettings *)newNotificationSettings;
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;
 #pragma clang diagnostic pop
 

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.h
@@ -38,6 +38,7 @@ withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0))
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 - (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+- (BOOL)updateUserNotificationSettings:(NSDictionary *)newSettings;
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings;
 #pragma clang diagnostic pop
 

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -179,6 +179,16 @@
     return NO;
 }
 
+- (NSDictionary *)currentUserNotificationSettings
+{
+    NSString *settingsKey = [[LPPushNotificationsManager sharedManager] leanplum_createUserNotificationSettingsKey];
+    NSDictionary *existingSettings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:settingsKey];
+    if (existingSettings != nil) {
+        return [UIUserNotificationSettings toRequestParams:existingSettings];
+    }
+    return @{};
+}
+
 #pragma mark - Push Notifications
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings
 {

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -136,8 +136,9 @@
         deviceAttributeParams[LP_PARAM_DEVICE_PUSH_TOKEN] = formattedToken;
     }
     // Get the push types if changed
-    NSDictionary* settings = [[UIApplication sharedApplication].currentUserNotificationSettings dictionary];
-    if ([self updateUserNotificationSettings:settings]) {
+    UIUserNotificationSettings* notificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+    if ([self updateUserNotificationSettings:notificationSettings]) {
+        NSDictionary* settings = [notificationSettings dictionary];
         [deviceAttributeParams addEntriesFromDictionary:[UIUserNotificationSettings toRequestParams:settings]];
     }
     
@@ -166,8 +167,9 @@
 }
 
 #pragma mark - Notification Settings
-- (BOOL)updateUserNotificationSettings:(NSDictionary *)newSettings
+- (BOOL)updateUserNotificationSettings:(UIUserNotificationSettings *)newNotificationSettings
 {
+    NSDictionary* newSettings = [newNotificationSettings dictionary];
     NSString *settingsKey = [[LPPushNotificationsManager sharedManager] leanplum_createUserNotificationSettingsKey];
     NSDictionary *existingSettings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:settingsKey];
     if (![existingSettings isEqualToDictionary:newSettings]) {
@@ -192,10 +194,10 @@
 #pragma mark - Push Notifications
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings
 {
-    NSDictionary* settings = [notificationSettings dictionary];
     // Send settings.
-    if ([self updateUserNotificationSettings:settings]) {
+    if ([self updateUserNotificationSettings:notificationSettings]) {
         NSString *existingToken = [[LPPushNotificationsManager sharedManager] pushToken];
+        NSDictionary* settings = [notificationSettings dictionary];
         NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:[UIUserNotificationSettings toRequestParams:settings]];
         if (existingToken) {
             params[LP_PARAM_DEVICE_PUSH_TOKEN] = existingToken;

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -136,9 +136,8 @@
         deviceAttributeParams[LP_PARAM_DEVICE_PUSH_TOKEN] = formattedToken;
     }
     // Get the push types if changed
-    UIUserNotificationSettings* notificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
-    if ([self updateUserNotificationSettings:notificationSettings]) {
-        NSDictionary* settings = [notificationSettings dictionary];
+    NSDictionary* settings = [[UIApplication sharedApplication].currentUserNotificationSettings dictionary];
+    if ([self updateUserNotificationSettings:settings]) {
         [deviceAttributeParams addEntriesFromDictionary:[UIUserNotificationSettings toRequestParams:settings]];
     }
     
@@ -167,9 +166,8 @@
 }
 
 #pragma mark - Notification Settings
-- (BOOL)updateUserNotificationSettings:(UIUserNotificationSettings *)newNotificationSettings
+- (BOOL)updateUserNotificationSettings:(NSDictionary *)newSettings
 {
-    NSDictionary* newSettings = [newNotificationSettings dictionary];
     NSString *settingsKey = [[LPPushNotificationsManager sharedManager] leanplum_createUserNotificationSettingsKey];
     NSDictionary *existingSettings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:settingsKey];
     if (![existingSettings isEqualToDictionary:newSettings]) {
@@ -194,10 +192,10 @@
 #pragma mark - Push Notifications
 - (void)sendUserNotificationSettingsIfChanged:(UIUserNotificationSettings *)notificationSettings
 {
+    NSDictionary* settings = [notificationSettings dictionary];
     // Send settings.
-    if ([self updateUserNotificationSettings:notificationSettings]) {
+    if ([self updateUserNotificationSettings:settings]) {
         NSString *existingToken = [[LPPushNotificationsManager sharedManager] pushToken];
-        NSDictionary* settings = [notificationSettings dictionary];
         NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:[UIUserNotificationSettings toRequestParams:settings]];
         if (existingToken) {
             params[LP_PARAM_DEVICE_PUSH_TOKEN] = existingToken;

--- a/Leanplum-SDK/Classes/Utilities/LPUtils.h
+++ b/Leanplum-SDK/Classes/Utilities/LPUtils.h
@@ -58,11 +58,6 @@
 + (void)handleException:(NSException *)exception;
 
 /**
- * Create Request Headers for network call
- */
-+ (NSDictionary *)createHeaders;
-
-/**
  * Whether swizzling flag is setup in plist file
  */
 + (BOOL)isSwizzlingEnabled;

--- a/Leanplum-SDK/Classes/Utilities/LPUtils.m
+++ b/Leanplum-SDK/Classes/Utilities/LPUtils.m
@@ -85,30 +85,6 @@
     [[LPExceptionHandler sharedExceptionHandler] reportException:exception];
 }
 
-/*
- Must include `Accept-Encoding: gzip` in the header
- Must include the phrase `gzip` in the `User-Agent` header
- https://cloud.google.com/appengine/kb/
- */
-+ (NSDictionary *)createHeaders {
-    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
-    NSString *userAgentString = [NSString stringWithFormat:@"%@/%@/%@/%@/%@/%@/%@/%@/%@",
-                                 infoDict[(NSString *)kCFBundleNameKey],
-                                 infoDict[(NSString *)kCFBundleVersionKey],
-                                 [LPAPIConfig sharedConfig].appId,
-                                 LEANPLUM_CLIENT,
-                                 LEANPLUM_SDK_VERSION,
-                                 [[UIDevice currentDevice] systemName],
-                                 [[UIDevice currentDevice] systemVersion],
-                                 LEANPLUM_SUPPORTED_ENCODING,
-                                 LEANPLUM_PACKAGE_IDENTIFIER];
-    
-    NSString *languageHeader = [NSString stringWithFormat:@"%@, en-us",
-                                [[NSLocale preferredLanguages] componentsJoinedByString:@", "]];
-    
-    return @{@"User-Agent": userAgentString, @"Accept-Language" : languageHeader, @"Accept-Encoding" : LEANPLUM_SUPPORTED_ENCODING};
-}
-
 +(BOOL)isSwizzlingEnabled
 {
     BOOL swizzlingEnabled = YES;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-125](https://leanplum.atlassian.net/browse/SDK-125)
JIRA Issue        | [SDK-88](https://leanplum.atlassian.net/browse/SDK-88)

## Background
Enable reuse of the Center Popup message template for Ads Pre-permission message.

Enable switching device ids after Leanplum has started.

## Implementation
1. Refactor the Center Popup message template to be more generic

2. Introduce `setDeviceIdInternal` method similar to the `setUserIdInternal`, to set a device id and 'switch' to this device.
The APIConfig deviceId should be updated as well as the VarCache, so the device id is persisted.
The device attributes must be updated to reflect the current device information.

Introduced common appVersion logic to reuse the code.

Refactor the notification settings request params as well as the request headers.

Introduce a way to test the `createArgsDictionaryForRequest` method of the Request Sender.
## Testing steps

## Is this change backwards-compatible?
Yes