### PR TITLE
Perform actions after start error

### DIFF
--- a/Example/Tests/Classes/LeanplumTest.m
+++ b/Example/Tests/Classes/LeanplumTest.m
@@ -892,6 +892,61 @@
 }
 
 /**
+ * Tests whether actions are executed after start even if the start failed.
+ */
+- (void) test_failed_start_triggers
+{
+    NSString* path = [[NSBundle mainBundle] pathForResource:@"simple_start_response"
+                                                     ofType:@"json"];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    
+    NSDictionary *startResponse = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+    
+    NSDictionary *messages = startResponse[LP_KEY_MESSAGES];
+    [[LPVarCache sharedCache] applyVariableDiffs:nil
+                          messages:messages
+                          variants:nil
+                           regions:nil
+                  variantDebugInfo:nil];
+    
+    [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+        return [request.URL.host isEqualToString:API_HOST];
+    } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+        NSString *errorResponseJson = @"{\
+        ""response"": [\
+            {\
+                ""success"": false,\
+                ""error"": {\
+                    ""message"": ""At least one of deviceId or userId is required.""\
+                }\
+            }\
+        ]\
+        }";
+        NSData *data = [errorResponseJson dataUsingEncoding:NSUTF8StringEncoding];
+        return [HTTPStubsResponse responseWithData:data statusCode:404 headers:nil];
+    }];
+    
+    [LeanplumHelper setup_production_test];
+    
+    XCTestExpectation *expectStartResponse = [self expectationWithDescription:@"startResponse"];
+
+    id mockLeanplumClass = OCMClassMock([Leanplum class]);
+    
+    [Leanplum startWithResponseHandler:^(BOOL success) {
+        XCTAssertFalse(success);
+    }];
+    
+    // maybePerformActions is executed after the start responses are triggered
+    id stub = OCMStub([mockLeanplumClass maybePerformActions:OCMArg.any withEventName:OCMArg.any withFilter:kLeanplumActionFilterAll fromMessageId:OCMArg.any withContextualValues:OCMArg.any]);
+    
+    [[stub andForwardToRealObject] andDo:^(NSInvocation *invocation) {
+        [expectStartResponse fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+/**
  * Tests whether setting user attributes and id works correctly.
  */
 - (void) test_user_attributes

--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -1018,6 +1018,12 @@ void leanplumExceptionHandler(NSException *exception);
         LP_END_TRY
 
         [self triggerStartResponse:NO];
+        
+        [self maybePerformActions:@[@"start", @"resume"]
+                    withEventName:nil
+                       withFilter:kLeanplumActionFilterAll
+                    fromMessageId:nil
+             withContextualValues:nil];
     }];
     [[LPRequestSender sharedInstance] sendIfConnected:request];
     [self triggerStartIssued];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-114](https://leanplum.atlassian.net/browse/SDK-114)

Perform actions (display in-app messages) on start even if the start fails.

## Background

## Implementation

## Testing steps

## Is this change backwards-compatible?
