### PR TITLE
Fix Xcode 12 different definitions

### DIFF
--- a/Leanplum-SDK/Classes/Internal/Leanplum.m
+++ b/Leanplum-SDK/Classes/Internal/Leanplum.m
@@ -1696,7 +1696,7 @@ void leanplumExceptionHandler(NSException *exception);
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)handleActionWithIdentifier:(NSString *)identifier
               forLocalNotification:(UILocalNotification *)notification
-                 completionHandler:(void (^)())completionHandler
+                 completionHandler:(void (^)(LeanplumUIBackgroundFetchResult))completionHandler
 {
     LP_TRY
     [[LPPushNotificationsManager sharedManager].handler didReceiveRemoteNotification:[notification userInfo]
@@ -1710,7 +1710,7 @@ void leanplumExceptionHandler(NSException *exception);
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)handleActionWithIdentifier:(NSString *)identifier
              forRemoteNotification:(NSDictionary *)notification
-                 completionHandler:(void (^)())completionHandler
+                 completionHandler:(void (^)(LeanplumUIBackgroundFetchResult))completionHandler
 {
     LP_TRY
     [[LPPushNotificationsManager sharedManager].handler didReceiveRemoteNotification:notification

--- a/Leanplum-SDK/Classes/Leanplum.h
+++ b/Leanplum-SDK/Classes/Leanplum.h
@@ -483,7 +483,7 @@ NS_SWIFT_NAME(defineAction(name:kind:args:options:completion:));
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)handleActionWithIdentifier:(NSString *)identifier
               forLocalNotification:(UILocalNotification *)notification
-                 completionHandler:(void (^)())completionHandler;
+                 completionHandler:(void (^)(LeanplumUIBackgroundFetchResult))completionHandler;
 #pragma clang diagnostic pop
 
 /**
@@ -493,7 +493,7 @@ NS_SWIFT_NAME(defineAction(name:kind:args:options:completion:));
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)handleActionWithIdentifier:(NSString *)identifier
              forRemoteNotification:(NSDictionary *)notification
-                 completionHandler:(void (^)())completionHandler;
+                 completionHandler:(void (^)(LeanplumUIBackgroundFetchResult))completionHandler;
 #pragma clang diagnostic pop
 
 /*


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------

Fix for `AST Deserialization Issue`:
` 'Leanplum' defined here has different definitions in different modules; first difference is this method`

## Background

## Implementation

## Testing steps

## Is this change backwards-compatible?
