### PR TITLE
[SDK-279] Fix cancel local notification

### DIFF
--- a/Leanplum-SDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
+++ b/Leanplum-SDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
@@ -188,7 +188,7 @@
                 for (UNNotificationRequest *request in requests) {
                     NSString *messageId = [[LPNotificationsManager shared] messageIdFromUserInfo:[request.content userInfo]];
                     if ([messageId isEqualToString:context.messageId]) {
-                        [UNUserNotificationCenter.currentNotificationCenter removeDeliveredNotificationsWithIdentifiers:@[request.identifier]];
+                        [UNUserNotificationCenter.currentNotificationCenter removePendingNotificationRequestsWithIdentifiers:@[request.identifier]];
                         if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
                             LPLog(LPInfo, @"Cancelled notification");
                         }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-279](https://leanplum.atlassian.net/browse/SDK-279)

## Background
Local Notification is not cancelled when the Unless condition is triggered.

## Implementation
Remove the pending notification that is scheduled to be sent.

## Testing steps

## Is this change backwards-compatible?
