### PR TITLE
Banner tap outside to close fix

### DIFF
--- a/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
@@ -65,17 +65,18 @@
         [self.dismissButton setHidden:YES];
     }
 
-    // passthrough view to send touch events to underlaying ViewController
-    LPHitView* passthroughView = (LPHitView *) self.view;
-    if (passthroughView) {
-        passthroughView.touchDelegate = self.presentingViewController.view;
-    }
-
     // add gesture recognizer to close message if tap outside to close is set to true.
     BOOL tapOutside = [self.context boolNamed:LPMT_ARG_HTML_TAP_OUTSIDE_TO_CLOSE];
     if (tapOutside) {
         UITapGestureRecognizer* gestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapOutside)];
         [self.view addGestureRecognizer:gestureRecognizer];
+    }
+    
+    // passthrough view to send touch events to underlaying ViewController
+    LPHitView* passthroughView = (LPHitView *) self.view;
+    if (passthroughView) {
+        passthroughView.shouldAllowTapToClose = tapOutside;
+        passthroughView.touchDelegate = self.presentingViewController.view;
     }
     
     _orientation = UIDevice.currentDevice.orientation;

--- a/Leanplum-SDK/Classes/MessageTemplates/Views/LPHitView.h
+++ b/Leanplum-SDK/Classes/MessageTemplates/Views/LPHitView.h
@@ -11,6 +11,7 @@
 @interface LPHitView : UIView
 
 @property (weak, nonatomic) UIView *touchDelegate;
+@property (assign) BOOL shouldAllowTapToClose;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event;
 

--- a/Leanplum-SDK/Classes/MessageTemplates/Views/LPHitView.m
+++ b/Leanplum-SDK/Classes/MessageTemplates/Views/LPHitView.m
@@ -18,7 +18,7 @@
         return nil;
     }
 
-    if (hitView != self) {
+    if (hitView != self || _shouldAllowTapToClose) {
         return hitView;
     }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-172](https://leanplum.atlassian.net/browse/SDK-172)
People Involved   | @dejan2k 

## Background
There seems to be an issue with  Banner closing when the Tap Outside to Close option is enabled.
The problem was that tap (touch) was forwarded to the view of the presenter view controller.

## Implementation
Intercept forwarding the tap (touch) to the view of the presenter when the tap to close option is set to true. So with any touch outside of the banner we can close it.
