### PR TITLE
Fix NSBlockOperation dealloc crash

### DIFF
--- a/Leanplum-SDK/Classes/Managers/Networking/LPRequest.m
+++ b/Leanplum-SDK/Classes/Managers/Networking/LPRequest.m
@@ -110,7 +110,9 @@
     if ([LPAPIConfig sharedConfig].token) {
         args[LP_PARAM_TOKEN] = [LPAPIConfig sharedConfig].token;
     }
-    [args addEntriesFromDictionary:self.params];
+    if (self.params && self.params.count > 0) {
+        [args addEntriesFromDictionary:self.params];
+    }
     
     // remove keys that are empty
     [args removeObjectForKey:@""];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-337](https://leanplum.atlassian.net/browse/SDK-337)
People Involved   | @dejan2k 

## Background
The SDK was throwing crash when trying to save request within operation block on background thread but the operation was somehow canceled (dealloc) before executing the block.

## Implementation
Before executing the operation check if it is canceled.

## Is this change backwards-compatible?
Yes
