### PR TITLE
[SDK-274] Fix open notification

### DIFF
--- a/Example/Tests/Classes/LPPushNotificationsHandlerTest.m
+++ b/Example/Tests/Classes/LPPushNotificationsHandlerTest.m
@@ -111,7 +111,14 @@
     if (!Leanplum.hasStarted){
         XCTAssertTrue([LeanplumHelper start_production_test]);
     }
-    [handler didReceiveRemoteNotification:userInfo
+    
+    // Change messageId so it is not a duplicate notification
+    NSDictionary* userInfo2 = @{
+                                @"_lpm": @"messageId_2",
+                                @"_lpx": @"test_action",
+                                @"aps" : @{@"alert": @"test"}};
+    
+    [handler didReceiveRemoteNotification:userInfo2
                                withAction:@"test_action"
                    fetchCompletionHandler: ^(LeanplumUIBackgroundFetchResult result) {
                                             [applicationNotificationExpectation fulfill];

--- a/Example/Tests/Classes/LPPushNotificationsHandlerTest.m
+++ b/Example/Tests/Classes/LPPushNotificationsHandlerTest.m
@@ -105,6 +105,12 @@
     
     //test when UNUserNotificationCenter.currentNotificationCenter.delegate is nil
     UNUserNotificationCenter.currentNotificationCenter.delegate = nil;
+    
+    // Requires Leanplum Start
+    // didReceiveRemoteNotification: UIApplicationState is Active -> calls handleNotification -> runs onContent on startIssued callback
+    if (!Leanplum.hasStarted){
+        XCTAssertTrue([LeanplumHelper start_production_test]);
+    }
     [handler didReceiveRemoteNotification:userInfo
                                withAction:@"test_action"
                    fetchCompletionHandler: ^(LeanplumUIBackgroundFetchResult result) {

--- a/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/Leanplum-SDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -230,6 +230,10 @@
         return;
     }
     
+    if ([self isDuplicateNotification:userInfo]) {
+        return;
+    }
+    
     void (^onContent)(void) = ^{
         if (completionHandler) {
             completionHandler(UIBackgroundFetchResultNewData);
@@ -266,11 +270,6 @@
                                  action:(NSString *)action
                                  active:(BOOL)active
 {
-    // Do not perform the action if the app is in background
-    if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
-        return;
-    }
-
     // Don't handle duplicate notifications.
     if ([self isDuplicateNotification:userInfo]) {
         return;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-274](https://leanplum.atlassian.net/browse/SDK-274)

## Background
Notification Open Action not working on iOS 13 when App is running in the background and the notification is opened from locked screen.

## Implementation
1) Remove the `UIApplicationState` check.

2) Add `isDuplicateNotification:userInfo` check. This prevents showing in-app confirm message for the Push (the one we show when a notification arrives while the app is in foreground) when it was opened. 
This was side effect from step 1. The notification open action was executed correctly but when returning to the app, this confirm was also shown.

## Testing steps
Manual Testing on iOS 14 and iOS 13 using Rondo iOS.

Locked | App State | Success
-- | -- | --
N/A | Foreground | Yes
Yes | Background | Yes
No | Background | Yes
Yes | Not running | Yes
No | Not running | Yes

## Is this change backwards-compatible?
Yes