### PR TITLE
Remove verbose logging

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.h
@@ -84,7 +84,6 @@ NS_SWIFT_NAME(Leanplum.Constants)
     BOOL _canDownloadContentMidSessionInProduction;
     BOOL _isTestMode;
     BOOL _isInPermanentFailureState;
-    BOOL _verboseLoggingInDevelopmentMode;
     BOOL _networkActivityIndicatorEnabled;
     NSString *_client;
     NSString *_sdkVersion;
@@ -107,7 +106,6 @@ NS_SWIFT_NAME(Leanplum.Constants)
 @property(strong, nonatomic) NSString *apiServlet;
 @property(assign, nonatomic) BOOL isTestMode;
 @property(assign, nonatomic) BOOL isInPermanentFailureState;
-@property(assign, nonatomic) BOOL verboseLoggingInDevelopmentMode;
 @property(strong, nonatomic) NSString *client;
 @property(strong, nonatomic) NSString *sdkVersion;
 @property(assign, nonatomic) BOOL networkActivityIndicatorEnabled;

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.m
@@ -54,7 +54,6 @@
         _canDownloadContentMidSessionInProduction = NO;
         _isTestMode = NO;
         _isInPermanentFailureState = NO;
-        _verboseLoggingInDevelopmentMode = NO;
         _networkActivityIndicatorEnabled = YES;
         _client = LEANPLUM_CLIENT;
         _sdkVersion = LEANPLUM_SDK_VERSION;

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -177,16 +177,6 @@ void leanplumExceptionHandler(NSException *exception);
     LP_END_TRY
 }
 
-+ (void)setVerboseLoggingInDevelopmentMode:(BOOL)enabled
-{
-    LP_TRY
-    [LPConstantsState sharedState].verboseLoggingInDevelopmentMode = enabled;
-    if (enabled) {
-        [Leanplum setLogLevel:Debug];
-    }
-    LP_END_TRY
-}
-
 + (void)setLogLevel:(LPLogLevel)level
 {
     LP_TRY

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -226,11 +226,6 @@ NS_SWIFT_NAME(setSocketHostName(_:port:));
 + (void)setFileHashingEnabledInDevelopmentMode:(BOOL)enabled;
 
 /**
- * Sets whether to enable verbose logging in development mode. Default: NO.
- */
-+ (void)setVerboseLoggingInDevelopmentMode:(BOOL)enabled;
-
-/**
 * Sets log level through the Leanplum SDK
 */
 + (void)setLogLevel:(LPLogLevel)level;

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
@@ -77,7 +77,7 @@ static BOOL swizzled = NO;
 }
 
 + (void)setup_development_test {
-    [Leanplum setVerboseLoggingInDevelopmentMode:YES];
+    [Leanplum setLogLevel:Debug];
     [Leanplum setAppId:APPLICATION_ID withDevelopmentKey:DEVELOPMENT_KEY];
 }
 


### PR DESCRIPTION
## Background
`setVerboseLoggingInDevelopmentMode` is obsolete, use `[Leanplum setLogLevel:Debug];` instead.
The method is already removed from the Android SDK.

## Implementation
Remove the method and the associated property. Use Debug Log level `[Leanplum setLogLevel:Debug];`
## Testing steps

## Is this change backwards-compatible?
