### PR TITLE
Remove dead code

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.h
@@ -78,13 +78,10 @@ NS_SWIFT_NAME(Leanplum.Constants)
     int _networkTimeoutSeconds;
     int _networkTimeoutSecondsForDownloads;
     int _syncNetworkTimeoutSeconds;
-    BOOL _checkForUpdatesInDevelopmentMode;
     BOOL _isDevelopmentModeEnabled;
     BOOL _loggingEnabled;
-    BOOL _canDownloadContentMidSessionInProduction;
     BOOL _isTestMode;
     BOOL _isInPermanentFailureState;
-    BOOL _networkActivityIndicatorEnabled;
     NSString *_client;
     NSString *_sdkVersion;
     // Counts how many user code blocks we're inside, to silence exceptions.
@@ -99,16 +96,13 @@ NS_SWIFT_NAME(Leanplum.Constants)
 @property(assign, nonatomic) int networkTimeoutSeconds;
 @property(assign, nonatomic) int networkTimeoutSecondsForDownloads;
 @property(assign, nonatomic) int syncNetworkTimeoutSeconds;
-@property(assign, nonatomic) BOOL checkForUpdatesInDevelopmentMode;
 @property(assign, nonatomic) BOOL isDevelopmentModeEnabled;
 @property(assign, nonatomic) BOOL loggingEnabled;
-@property(assign, nonatomic) BOOL canDownloadContentMidSessionInProduction;
 @property(strong, nonatomic) NSString *apiServlet;
 @property(assign, nonatomic) BOOL isTestMode;
 @property(assign, nonatomic) BOOL isInPermanentFailureState;
 @property(strong, nonatomic) NSString *client;
 @property(strong, nonatomic) NSString *sdkVersion;
-@property(assign, nonatomic) BOOL networkActivityIndicatorEnabled;
 @property(assign, nonatomic) BOOL isLocationCollectionEnabled;
 @property(assign, nonatomic) BOOL isInboxImagePrefetchingEnabled;
 

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPConstants.m
@@ -48,13 +48,10 @@
         _networkTimeoutSeconds = 10;
         _networkTimeoutSecondsForDownloads = 15;
         _syncNetworkTimeoutSeconds = 5;
-        _checkForUpdatesInDevelopmentMode = YES;
         _isDevelopmentModeEnabled = NO;
         _loggingEnabled = NO;
-        _canDownloadContentMidSessionInProduction = NO;
         _isTestMode = NO;
         _isInPermanentFailureState = NO;
-        _networkActivityIndicatorEnabled = YES;
         _client = LEANPLUM_CLIENT;
         _sdkVersion = LEANPLUM_SDK_VERSION;
         _isLocationCollectionEnabled = YES;

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPInternalState.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPInternalState.h
@@ -16,11 +16,10 @@
 @property(strong, nonatomic) NSMutableSet *startResponders, *variablesChangedResponders, *noDownloadsResponders;
 @property(assign, nonatomic) NSUncaughtExceptionHandler *customExceptionHandler;
 @property(strong, nonatomic) LPRegisterDevice *registration;
-@property(assign, nonatomic) BOOL calledStart, hasStarted, hasStartedAndRegisteredAsDeveloper, startSuccessful, issuedStart, stripViewControllerFromState;
+@property(assign, nonatomic) BOOL calledStart, hasStarted, hasStartedAndRegisteredAsDeveloper, startSuccessful, issuedStart;
 @property(strong, nonatomic) LPActionManager *actionManager;
 @property(strong, nonatomic) NSString *appVersion;
 @property(strong, nonatomic) NSMutableArray *userAttributeChanges;
-@property(assign, nonatomic) BOOL isScreenTrackingEnabled;
 @property(assign, nonatomic) BOOL isVariantDebugInfoEnabled;
 @property(assign, nonatomic) BOOL calledHandleNotification;
 

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/LPInternalState.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/LPInternalState.m
@@ -38,8 +38,6 @@
         _startSuccessful = NO;
         _actionManager = nil;
         _userAttributeChanges = [NSMutableArray array];
-        _stripViewControllerFromState = NO;
-        _isScreenTrackingEnabled = NO;
         _calledHandleNotification = NO;
     }
     return self;

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -170,13 +170,6 @@ void leanplumExceptionHandler(NSException *exception);
     [LPConstantsState sharedState].sdkVersion = version;
 }
 
-+ (void)setFileHashingEnabledInDevelopmentMode:(BOOL)enabled
-{
-    LP_TRY
-    [LPConstantsState sharedState].checkForUpdatesInDevelopmentMode = enabled;
-    LP_END_TRY
-}
-
 + (void)setLogLevel:(LPLogLevel)level
 {
     LP_TRY
@@ -214,20 +207,6 @@ void leanplumExceptionHandler(NSException *exception);
     LP_TRY
     [LPConstantsState sharedState].networkTimeoutSeconds = seconds;
     [LPConstantsState sharedState].networkTimeoutSecondsForDownloads = downloadSeconds;
-    LP_END_TRY
-}
-
-+ (void)setNetworkActivityIndicatorEnabled:(BOOL)enabled
-{
-    LP_TRY
-    [LPConstantsState sharedState].networkActivityIndicatorEnabled = enabled;
-    LP_END_TRY
-}
-
-+ (void)setCanDownloadContentMidSessionInProductionMode:(BOOL)value
-{
-    LP_TRY
-    [LPConstantsState sharedState].canDownloadContentMidSessionInProduction = value;
     LP_END_TRY
 }
 
@@ -1938,21 +1917,6 @@ void leanplumExceptionHandler(NSException *exception);
     [[LPCountAggregator sharedAggregator] incrementCount:@"set_variant_debug_info_enabled"];
 }
 
-+ (void)trackAllAppScreens
-{
-    [Leanplum trackAllAppScreensWithMode:LPTrackScreenModeDefault];
-}
-
-+ (void)trackAllAppScreensWithMode:(LPTrackScreenMode)trackScreenMode;
-{
-    RETURN_IF_NOOP;
-
-    LP_TRY
-    BOOL stripViewControllerFromState = trackScreenMode == LPTrackScreenModeStripViewController;
-    [[LPInternalState sharedState] setStripViewControllerFromState:stripViewControllerFromState];
-    LP_END_TRY
-}
-
 + (void)trackPurchase:(NSString *)event withValue:(double)value
       andCurrencyCode:(NSString *)currencyCode andParameters:(NSDictionary *)params
 {
@@ -2308,11 +2272,6 @@ andParameters:(NSDictionary *)params
         return;
     }
     LP_TRY
-    if (state &&
-        [[LPInternalState sharedState] stripViewControllerFromState] &&
-        [state hasSuffix:@"ViewController"]) {
-        state = [state substringToIndex:([state length] - [@"ViewController" length])];
-    }
     NSMutableDictionary *args = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                  state ? state : @"", LP_PARAM_STATE, nil];
     if (info) {

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -204,28 +204,6 @@ NS_SWIFT_NAME(setSocketHostName(_:port:));
 /**@}*/
 
 /**
- * Sets whether to show the network activity indicator in the status bar when making requests.
- * Default: YES.
- */
-+ (void)setNetworkActivityIndicatorEnabled:(BOOL)enabled;
-
-/**
- * Advanced: Whether new variables can be downloaded mid-session. By default, this is disabled.
- * Currently, if this is enabled, new variables can only be downloaded if a push notification is sent
- * while the app is running, and the notification's metadata hasn't be downloaded yet.
- */
-+ (void)setCanDownloadContentMidSessionInProductionMode:(BOOL)value;
-
-/**
- * Modifies the file hashing setting in development mode.
- * By default, Leanplum will hash file variables to determine if they're modified and need
- * to be uploaded to the server if we're running in the simulator.
- * Setting this to NO will reduce startup latency in development mode, but it's possible
- * that Leanplum will not always have the most up-to-date versions of your resources.
- */
-+ (void)setFileHashingEnabledInDevelopmentMode:(BOOL)enabled;
-
-/**
 * Sets log level through the Leanplum SDK
 */
 + (void)setLogLevel:(LPLogLevel)level;
@@ -612,34 +590,6 @@ NS_SWIFT_NAME(advance(state:info:params:));
 + (void)resumeState;
 
 /**
- * Automatically tracks all of the screens in the app as states.
- * You should not use this in conjunction with advanceTo as the user can only be in
- * 1 state at a time. This method requires LeanplumUIEditor module.
- */
-+ (void)trackAllAppScreens
-NS_SWIFT_NAME(trackAppScreens());
-
-/**
- * LPTrackScreenMode enum.
- * LPTrackScreenModeDefault mans that states are the full view controller type name.
- * LPTrackScreenModeStripViewController will cause the string "ViewController" to be stripped from
- * the end of the state.
- */
-typedef NS_ENUM(NSUInteger, LPTrackScreenMode) {
-    LPTrackScreenModeDefault NS_SWIFT_NAME(defaultMode) = 0,
-    LPTrackScreenModeStripViewController NS_SWIFT_NAME(stripMode)
-} NS_SWIFT_NAME(Leanplum.TrackScreenMode);
-
-/**
- * Automatically tracks all of the screens in the app as states.
- * You should not use this in conjunction with advanceTo as the user can only be in
- * 1 state at a time. This method requires LeanplumUIEditor module.
- * @param trackScreenMode Choose mode for display. Default is the view controller type name.
- */
-+ (void)trackAllAppScreensWithMode:(LPTrackScreenMode)trackScreenMode
-NS_SWIFT_NAME(trackAppScreens(mode:));
-
-/**
  * Manually track purchase event with currency code in your application. It is advised to use
  * trackInAppPurchases to automatically track IAPs.
  */
@@ -756,8 +706,10 @@ NS_SWIFT_UNAVAILABLE("use forceContentUpdate(completion:)");
 /**
  * This should be your first statement in a unit test. This prevents
  * Leanplum from communicating with the server.
+ * Deprecated. Use [Leanplum setTestModeEnabled:YES] instead.
  */
-+ (void)enableTestMode;
++ (void)enableTestMode
+__attribute__((deprecated("Use [Leanplum setTestModeEnabled:YES] instead.")));
 
 /**
  * Used to enable or disable test mode. Test mode prevents Leanplum from

--- a/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -354,7 +354,7 @@
                                                                      LP_PARAM_INCLUDE_DEFAULTS: @(NO),
                                                                      LP_PARAM_INCLUDE_MESSAGE_ID: messageId
                                                                     }]
-                                                    andRequestType:Immediate];
+                                  andRequestType:Immediate];
             [request onResponse:^(id<LPNetworkOperationProtocol> operation, NSDictionary *response) {
                 LP_TRY
                 NSDictionary *values = response[LP_KEY_VARS];
@@ -365,33 +365,19 @@
                 NSString *varsSignature = response[LP_KEY_VARS_SIGNATURE];
                 NSArray *localCaps = response[LP_KEY_LOCAL_CAPS];
                 
-                if (![LPConstantsState sharedState].canDownloadContentMidSessionInProduction ||
-                    [values isEqualToDictionary:[LPVarCache sharedCache].diffs]) {
-                    values = nil;
-                    varsJson = nil;
-                    varsSignature = nil;
-                }
-                if ([messages isEqualToDictionary:[LPVarCache sharedCache].messageDiffs]) {
-                    messages = nil;
-                }
-                if ([regions isEqualToDictionary:[LPVarCache sharedCache].regions]) {
-                    regions = nil;
-                }
-                if (values || messages || regions) {
-                    [[LPVarCache sharedCache] applyVariableDiffs:values
-                                                        messages:messages
-                                                        variants:variants
-                                                       localCaps:localCaps
-                                                         regions:regions
-                                                variantDebugInfo:nil
-                                                        varsJson:varsJson
-                                                   varsSignature:varsSignature];
-                    if (onCompleted) {
-                        onCompleted();
-                    }
+                [[LPVarCache sharedCache] applyVariableDiffs:values
+                                                    messages:messages
+                                                    variants:variants
+                                                   localCaps:localCaps
+                                                     regions:regions
+                                            variantDebugInfo:nil
+                                                    varsJson:varsJson
+                                               varsSignature:varsSignature];
+                if (onCompleted) {
+                    onCompleted();
                 }
                 LP_END_TRY
-             }];
+            }];
             [[LPRequestSender sharedInstance] send:request];
         }
         LP_BEGIN_USER_CODE


### PR DESCRIPTION
## Background
Remove dead code:
- `setFileHashingEnabledInDevelopmentMode` (uses old network layer)
- `checkForUpdatesInDevelopmentMode` (used by setFileHashingEnabledInDevelopmentMode)
- `setNetworkActivityIndicatorEnabled` (uses old network layer)
- `stripViewControllerFromState` (used with the deprecated UIEditor)
- `trackAllAppScreens` (only works with the deprecated UIEditor)
- `trackAllAppScreensWithMode` (only works with the deprecated UIEditor)
- `LPTrackScreenMode` (only works with the deprecated UIEditor)

Unnecessary check:
- `canDownloadContentMidSessionInProduction` - apply diffs in production when `getVars` is called to fetch new data. All data is already returned by the server (the `includeMessage` param does not change this behavior).

Deprecated:
- `enableTestMode` (use `setTestMode:` instead)

## Implementation

## Testing steps

## Is this change backwards-compatible?
