### PR TITLE
ForceContentUpdate with boolean flag

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -2351,11 +2351,20 @@ andParameters:(NSDictionary *)params
 
 + (void)forceContentUpdate:(LeanplumVariablesChangedBlock)block
 {
+    [Leanplum forceContentUpdateWithBlock:^(BOOL success) {
+        if (block) {
+            block();
+        }
+    }];
+}
+
++ (void)forceContentUpdateWithBlock:(LeanplumForceContentUpdateBlock)updateBlock
+{
     [[LPCountAggregator sharedAggregator] incrementCount:@"force_content_update"];
     
     if (IS_NOOP) {
-        if (block) {
-            block();
+        if (updateBlock) {
+            updateBlock(NO);
         }
         return;
     }
@@ -2405,13 +2414,13 @@ andParameters:(NSDictionary *)params
             [[self inbox] triggerInboxSyncedWithStatus:YES withCompletionHandler:nil];
         }
         LP_END_TRY
-        if (block) {
-            block();
+        if (updateBlock) {
+            updateBlock(YES);
         }
     }];
     [request onError:^(NSError *error) {
-        if (block) {
-            block();
+        if (updateBlock) {
+            updateBlock(NO);
         }
         [[self inbox] triggerInboxSyncedWithStatus:NO withCompletionHandler:nil];
     }];

--- a/LeanplumSDK/LeanplumSDK/Classes/LPVar.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/LPVar.h
@@ -27,6 +27,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^LeanplumVariablesChangedBlock)(void);
+typedef void (^LeanplumForceContentUpdateBlock)(BOOL success);
 
 @class LPVar;
 

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -704,6 +704,15 @@ NS_SWIFT_UNAVAILABLE("use forceContentUpdate(completion:)");
 + (void)forceContentUpdate:(nullable LeanplumVariablesChangedBlock)block;
 
 /**
+ * Forces content to update from the server. If variables have changed, the
+ * appropriate callbacks will fire. Use sparingly as if the app is updated,
+ * you'll have to deal with potentially inconsistent state or user experience.
+ * The provided callback has a boolean flag whether the update was successful or not. The callback fires regardless
+ * of whether the variables have changed.
+ */
++ (void)forceContentUpdateWithBlock:(LeanplumForceContentUpdateBlock)updateBlock;
+
+/**
  * This should be your first statement in a unit test. This prevents
  * Leanplum from communicating with the server.
  * Deprecated. Use [Leanplum setTestModeEnabled:YES] instead.


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-577](https://leanplum.atlassian.net/browse/SDK-577)
People Involved   | @nzagorchev 

## Background
Adds a success flag that indicates whether the getVars API request was successful or not.

## Implementation
Add a new method since the current one cannot be overloaded with a different block.

## Testing steps

## Is this change backwards-compatible?
Yes