### PR TITLE
Fix unmuted notifications not working when app is closed

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m
@@ -430,13 +430,14 @@
         return;
     }
 
+    BOOL active = UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
+
     void (^onContent)(void) = ^{
         if (completionHandler) {
             completionHandler(UIBackgroundFetchResultNewData);
         }
         BOOL hasAlert = userInfo[@"aps"][@"alert"] != nil;
         if (hasAlert) {
-            BOOL active = UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
             [self maybePerformNotificationActions:userInfo action:nil active:active];
         }
     };


### PR DESCRIPTION
I encountered an issue with the Leanplum iOS SDK not handling push notifications correctly under the following circumstances:
1.	The app is not running
2.	An unmuted push notification is sent
3.	The push notification contains an action

Under these circumstances the action will not be executed. See support ticket 46521 for an example push notification.

After digging into the code to see what’s wrong (suspecting our code initially) I found the following:
The `LPPushNotificationsHandler` has several places where it handles push notifications by calling `maybePerformNotificationActions`. There is one piece of problematic code that only affects unmuted notifications (this is why muted notifications don't exhibit this issue):
https://github.com/Leanplum/Leanplum-iOS-SDK/blob/1d723c1eb5c8050512a63e60f462e384b21db5ec/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m#L479-L495

The issue is that that when handleNotificationResponse is called, the app is inactive. However, we wait for Leanplum onStartIssued, check whether the application is active and then call maybePerformNotificationActions.

This means that we are checking whether the application is activate too late. We waited to Leanplum’s Start function to be called, but we have not waited for Leanplum to finish starting, therefore the notification will be discarded here:
https://github.com/Leanplum/Leanplum-iOS-SDK/blob/master/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m#L319

Any further attempts to handle the notification will be discarded by the duplication filtering logic:
https://github.com/Leanplum/Leanplum-iOS-SDK/blob/master/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m#L267-L270

PS: There is a similar piece of code here:
https://github.com/Leanplum/Leanplum-iOS-SDK/blob/1d723c1eb5c8050512a63e60f462e384b21db5ec/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m#L485
It’s doesn't the same issue because that function is only called if the application is in the foreground, see:
https://github.com/Leanplum/Leanplum-iOS-SDK/blob/master/LeanplumSDK/LeanplumSDK/Classes/Notifications/Push/LPPushNotificationsHandler.m#L468
