### PR TITLE
Xcode 12 compatibility

### DIFF
--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumNotificationsManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumNotificationsManagerTest.swift
@@ -159,6 +159,12 @@ class LeanplumNotificationsManagerTest: XCTestCase {
             return false
         }
         
+        if UIApplication.shared.keyWindow == nil {
+            let window = UIWindow()
+            window.rootViewController = UIViewController()
+            window.makeKeyAndVisible()
+        }
+        
         // Other UIAlertControllers can block the notification LPUIAlert
         // Dismiss all controllers so after notificationReceived is executed, the top one will be the LPUIAlert
         dismissAllPresentedControllers(block: {

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumPushNotificationsProxyTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumPushNotificationsProxyTest.swift
@@ -81,7 +81,7 @@ class LeanplumPushNotificationsProxyTest: XCTestCase {
         let manager = Leanplum.notificationsManager() as! LeanplumNotificationsManagerMock
         manager.proxy.userNotificationCenter(willPresent: notif) { options in }
         
-        guard let notif = manager.userInfoProcessed, let occId = notif[NotificationTestHelper.occurrenceIdKey] else {
+        guard let notifProcessed = manager.userInfoProcessed, let occId = notifProcessed[NotificationTestHelper.occurrenceIdKey] else {
             XCTFail(NotificationTestHelper.occurrenceIdNilError)
             return
         }
@@ -99,7 +99,7 @@ class LeanplumPushNotificationsProxyTest: XCTestCase {
         // didReceiveRemoteNotification is called after willPresent if push has content-available flag
         manager.proxy.didReceiveRemoteNotification(userInfo: userInfo) { result in }
         
-        guard let notif = manager.userInfoProcessed, let occId = notif[NotificationTestHelper.occurrenceIdKey] else {
+        guard let notifProcessed = manager.userInfoProcessed, let occId = notifProcessed[NotificationTestHelper.occurrenceIdKey] else {
             XCTFail(NotificationTestHelper.occurrenceIdNilError)
             return
         }
@@ -233,6 +233,10 @@ fileprivate class UNNotificationResponseTestCoder: NSCoder {
     
     init(with request: UNNotificationRequest) {
         self.request = request
+    }
+    
+    override func decodeInt64(forKey key: String) -> Int64 {
+        return 0
     }
     
     override func decodeObject(forKey key: String) -> Any? {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Unit Tests Swift compilation compatibility with Xcode 12.
The same code compiles successfully on Xcode 13.

Addresses CompileSwift errors.
`Abort trap: 6 Command CompileSwift failed with a nonzero exit code`

## Implementation
The compilation will fail on Xcode 12 if a variable with the same name is already defined and that same name is used in `guard let` statement (`if let` works). Example:
```
let a = ""
var b:Bool?
guard let a = b else {
    return
}
```
The above style is also confusing, so this PR fixes it.

`UNNotificationResponseTestCoder` tried to call abstract `decodeInt64ForKey` for `actionOptions` key. Implementing the method and ignoring that key.

## Testing steps
Tested with Xcode 12.0

## Is this change backwards-compatible?
Yes