### PR TITLE
Feature/set locale

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -862,10 +862,8 @@ void leanplumExceptionHandler(NSException *exception);
     // Setup parameters.
     NSString *versionName = [self appVersion];
     UIDevice *device = [UIDevice currentDevice];
-    NSLocale *currentLocale = [NSLocale currentLocale];
-    NSString *currentLocaleString = [NSString stringWithFormat:@"%@_%@",
-                                     [[NSLocale preferredLanguages] objectAtIndex:0],
-                                     [currentLocale objectForKey:NSLocaleCountryCode]];
+    NSString *currentLocaleString = [self.locale localeIdentifier];
+
     // Set the device name. But only if running in development mode.
     NSString *deviceName = @"";
     if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
@@ -2249,12 +2247,33 @@ andParameters:(NSDictionary *)params
     [[LPRequestSender sharedInstance] send:request];
 }
 
++ (NSLocale *)systemLocale {
+    static NSLocale * _systemLocale = nil;
+    if (!_systemLocale) {
+        NSLocale *currentLocale = [NSLocale currentLocale];
+        NSString *currentLocaleString = [NSString stringWithFormat:@"%@_%@",
+                                         [[NSLocale preferredLanguages] objectAtIndex:0],
+                                         [currentLocale objectForKey:NSLocaleCountryCode]];
+        _systemLocale = [[NSLocale alloc] initWithLocaleIdentifier:currentLocaleString];
+    }
+    return _systemLocale;
+}
+
+static NSLocale * _locale;
++ (NSLocale *)locale
+{
+    return _locale ?: self.systemLocale;
+}
+
 + (void)setLocale:(NSLocale *)locale
 {
-    LPRequest *request = [LPRequestFactory setUserAttributesWithParams:@{
-        LP_KEY_LOCALE: [locale localeIdentifier]
-    }];
-    [[LPRequestSender sharedInstance] send:request];
+    _locale = locale;
+    if ([self hasStarted]) {
+        LPRequest *request = [LPRequestFactory setUserAttributesWithParams:@{
+            LP_KEY_LOCALE: [locale localeIdentifier]
+        }];
+        [[LPRequestSender sharedInstance] send:request];
+    }
 }
 
 + (void)advanceTo:(NSString *)state

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -2249,6 +2249,14 @@ andParameters:(NSDictionary *)params
     [[LPRequestSender sharedInstance] send:request];
 }
 
++ (void)setLocale:(NSLocale *)locale
+{
+    LPRequest *request = [LPRequestFactory setUserAttributesWithParams:@{
+        LP_KEY_LOCALE: [locale localeIdentifier]
+    }];
+    [[LPRequestSender sharedInstance] send:request];
+}
+
 + (void)advanceTo:(NSString *)state
 {
     [self advanceTo:state withInfo:nil];

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -527,6 +527,12 @@ NS_SWIFT_NAME(setUserId(_:attributes:));
 NS_SWIFT_NAME(setTrafficSource(info:));
 
 /**
+ * Updates a user locale after session start.
+ */
++(void)setLocale:(NSLocale *)locale
+NS_SWIFT_NAME(setLocale(_:));
+
+/**
  * @{
  * Advances to a particular state in your application. The string can be
  * any value of your choosing, and will show up in the dashboard.

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Extensions/Leanplum+Extensions.h
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Extensions/Leanplum+Extensions.h
@@ -31,6 +31,8 @@
 
 @interface Leanplum(UnitTest)
 
++ (NSLocale *)systemLocale;
+
 + (void)reset;
 
 + (void)maybePerformActions:(NSArray *)whenConditions

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumTest.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumTest.m
@@ -1076,6 +1076,45 @@
 }
 
 /**
+ * Tests setting the user locale after Leanplum start
+ */
+- (void) test_set_locale
+{
+    NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:@"ab_CD"];
+
+    [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+        return [request.URL.host isEqualToString:API_HOST];
+    } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+        NSString *response_file = OHPathForFile(@"simple_start_response.json", self.class);
+        return [HTTPStubsResponse responseWithFileAtPath:response_file statusCode:200
+                                                   headers:@{@"Content-Type":@"application/json"}];
+    }];
+
+    [LPRequestSender validate_request:^BOOL(NSString *method, NSString *apiMethod,
+                                        NSDictionary *params) {
+        XCTAssertEqualObjects(apiMethod, @"start");
+        return YES;
+    }];
+
+    XCTAssertTrue([LeanplumHelper start_production_test]);
+
+    dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+    [Leanplum onStartResponse:^(BOOL success) {
+        XCTAssertTrue(success);
+        [Leanplum setLocale:locale];
+        dispatch_semaphore_signal(semaphor);
+    }];
+    long timedOut = dispatch_semaphore_wait(semaphor, [LeanplumHelper default_dispatch_time]);
+    XCTAssertTrue(timedOut == 0);
+    XCTAssertTrue([Leanplum hasStarted]);
+
+    [LPRequestSender validate_request_args_dictionary:^(NSDictionary *args) {
+        XCTAssertTrue([args[LP_KEY_LOCALE] isEqualToString:[locale localeIdentifier]]);
+        XCTAssertFalse([args[LP_KEY_LOCALE] isEqualToString:[[NSLocale currentLocale] localeIdentifier]]);
+    }];
+}
+
+/**
  * Tests track with events of same type , priority and countdown.
  */
 - (void) test_track_events_priority_countDown


### PR DESCRIPTION
## Proposed Changes

Currently the `locale` parameter is sent along when calling `start()`, but there is no way to override it.

This PR introduces `setLocale` API which can be called before or after `start()`.
The Leanplum class now have private property for overriding the system locale.

Similar approach has been done in https://github.com/Leanplum/Leanplum-JavaScript-SDK/pull/140