### PR TITLE
Rename LPLogLevel enum cases

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Managers/LPLogManager.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Managers/LPLogManager.h
@@ -11,10 +11,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, LPLogLevel) {
-    Off = 0,
-    Error,
-    Info,
-    Debug
+    LPLogLevelOff = 0,
+    LPLogLevelError,
+    LPLogLevelInfo,
+    LPLogLevelDebug
 } NS_SWIFT_NAME(Leanplum.LogLevel);
 
 typedef NS_ENUM(NSUInteger, LPLogType) {

--- a/LeanplumSDK/LeanplumSDK/Classes/Managers/LPLogManager.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Managers/LPLogManager.m
@@ -17,7 +17,7 @@
 + (void)maybeSendLog:(NSString *)message;
 @end
 @implementation LPLogManager
-static LPLogLevel logLevel = Info;
+static LPLogLevel logLevel = LPLogLevelInfo;
 
 +(void)setLogLevel:(LPLogLevel)level
 {
@@ -123,7 +123,7 @@ void LPLog(LPLogType type, NSString *format, ...) {
             logType = @"DEBUG";
             message = [NSString stringWithFormat:@"[%@] [%@]: %@", leanplumString, logType, formattedMessage];
             [LPLogManager maybeSendLog:message];
-            if (level < Debug) {
+            if (level < LPLogLevelDebug) {
                 return;
             }
             break;
@@ -131,7 +131,7 @@ void LPLog(LPLogType type, NSString *format, ...) {
             logType = @"INFO";
             message = [NSString stringWithFormat:@"[%@] [%@]: %@", leanplumString, logType, formattedMessage];
             [LPLogManager maybeSendLog:message];
-            if (level < Info) {
+            if (level < LPLogLevelInfo) {
                 return;
             }
             break;
@@ -139,7 +139,7 @@ void LPLog(LPLogType type, NSString *format, ...) {
             logType = @"ERROR";
             message = [NSString stringWithFormat:@"[%@] [%@]: %@", leanplumString, logType, formattedMessage];
             [LPLogManager maybeSendLog:message];
-            if (level < Error) {
+            if (level < LPLogLevelError) {
                 return;
             }
             break;

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
@@ -77,7 +77,7 @@ static BOOL swizzled = NO;
 }
 
 + (void)setup_development_test {
-    [Leanplum setLogLevel:Debug];
+    [Leanplum setLogLevel:LPLogLevelDebug];
     [Leanplum setAppId:APPLICATION_ID withDevelopmentKey:DEVELOPMENT_KEY];
 }
 


### PR DESCRIPTION
Renamed the LPLogLevel enum cases to be prefixed with `LPLogLevel`.  This helps avoid conflicts with other SDKs that define the same enum names globally.

- Renamed LPLogLevel cases to have the `LPLogLevel` prefix
- Updated usage within the SDK and tests

What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [JIRA_TICKET_ID](https://leanplum.atlassian.net/browse/JIRA_TICKET_ID)
People Involved   | @colleague1, @colleague2

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
We would like to update the latest SDK without having to use a forked version.  Currently the LPLogLevel enums collide with another 3rd party SDK that we don't have the ability to change.

## Implementation
Prefixed LPLogLevel cases with `LPLogLevel`

## Testing steps

## Is this change backwards-compatible?
No - this will cause any applications referencing this enum to update the name.