### PR TITLE
Improve Notification classes structure

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationSettings.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationSettings.swift
@@ -121,8 +121,10 @@ class LeanplumNotificationSettings {
         }
     }
     
-    //method for retrieving notification settings from UIApplication
-    //used for iOS 9 devices (older then iOS 10)
+    /**
+     * Retrieves notification settings from UIApplication
+     * Used for iOS 9 devices (older than iOS 10)
+     */
     private func getSettingsFromUIApplication() -> [AnyHashable: Any] {
         guard let settings = UIApplication.shared.currentUserNotificationSettings?.dictionary else {
             return [:]

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager+Utils.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager+Utils.swift
@@ -166,4 +166,32 @@ import Foundation
             leanplumIncrementUserCodeBlock(1)
         }
     }
+    
+    func getNotificationId(_ userInfo: [AnyHashable:Any]) -> String {
+        if let occId = userInfo[LP_KEY_PUSH_OCCURRENCE_ID] {
+            return String(describing: occId)
+        }
+        return "-1"
+    }
+    
+    func areActionsEmbedded(_ userInfo:[AnyHashable:Any]) -> Bool {
+        return userInfo[LP_KEY_PUSH_ACTION] != nil ||
+        userInfo[LP_KEY_PUSH_CUSTOM_ACTIONS] != nil
+    }
+    
+    func isMuted(_ userInfo:[AnyHashable:Any]) -> Bool {
+        return userInfo[LP_KEY_PUSH_MUTE_IN_APP] != nil || userInfo[LP_KEY_PUSH_NO_ACTION_MUTE] != nil || userInfo[LP_KEY_PUSH_NO_ACTION] != nil
+    }
+    
+    func getNotificationText(_ userInfo:[AnyHashable:Any]) -> String? {
+        // Handle payload "aps":{ "alert": "message" } and "aps":{ "alert": { "title": "...", "body": "message" }
+        if let aps = userInfo["aps"] as? [AnyHashable : Any] {
+            if let alert = aps["alert"] as? [AnyHashable : Any] {
+                return alert["body"] as? String
+            } else {
+                return aps["alert"] as? String
+            }
+        }
+        return nil
+    }
 }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumUtils.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumUtils.swift
@@ -9,41 +9,20 @@ import Foundation
 
 public class LeanplumUtils: NSObject {
 
-    static func lpLog(type:Leanplum.LogTypeNew, format:String, _ args:CVarArg...) {
+    /**
+     * Swift equivalent of the LPLog function
+     */
+    public static func lpLog(type:Leanplum.LogTypeNew, format:String, _ args:CVarArg...) {
         LPLogv(type, format, getVaList(args))
     }
     
-    static func getNotificationId(_ userInfo: [AnyHashable:Any]) -> String {
-        if let occId = userInfo[LP_KEY_PUSH_OCCURRENCE_ID] {
-            return String(describing: occId)
-        }
-        return "-1"
-    }
-    
+    /**
+     * Returns Leanplum message Id from Notification userInfo.
+     * Use this method to identify Leanplum Notifications
+     */
     @objc public static func messageIdFromUserInfo(_ userInfo: [AnyHashable : Any]) -> String? {
         if let messageId = userInfo[LP_KEY_PUSH_MESSAGE_ID] ?? userInfo[LP_KEY_PUSH_MUTE_IN_APP] ?? userInfo[LP_KEY_PUSH_NO_ACTION] ?? userInfo[LP_KEY_PUSH_NO_ACTION_MUTE] {
             return String(describing: messageId)
-        }
-        return nil
-    }
-    
-    static func areActionsEmbedded(_ userInfo:[AnyHashable:Any]) -> Bool {
-        return userInfo[LP_KEY_PUSH_ACTION] != nil ||
-        userInfo[LP_KEY_PUSH_CUSTOM_ACTIONS] != nil
-    }
-    
-    static func isMuted(_ userInfo:[AnyHashable:Any]) -> Bool {
-        return userInfo[LP_KEY_PUSH_MUTE_IN_APP] != nil || userInfo[LP_KEY_PUSH_NO_ACTION_MUTE] != nil || userInfo[LP_KEY_PUSH_NO_ACTION] != nil
-    }
-    
-    static func getNotificationText(_ userInfo:[AnyHashable:Any]) -> String? {
-        // Handle payload "aps":{ "alert": "message" } and "aps":{ "alert": { "title": "...", "body": "message" }
-        if let aps = userInfo["aps"] as? [AnyHashable : Any] {
-            if let alert = aps["alert"] as? [AnyHashable : Any] {
-                return alert["body"] as? String
-            } else {
-                return aps["alert"] as? String
-            }
         }
         return nil
     }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // LP Swizzling looks for the selector in the same class
 extension NSObject {
+    // MARK: - Register For Remote Notifications
     @objc func leanplum_application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Leanplum.notificationsManager().didRegisterForRemoteNotificationsWithDeviceToken(deviceToken)
         
@@ -30,6 +31,7 @@ extension NSObject {
         }
     }
     
+    // MARK: - didReceiveRemoteNotification
     @objc func leanplum_application(_ application: UIApplication,
                                      didReceiveRemoteNotification userInfo: [AnyHashable : Any],
                                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
@@ -82,6 +84,7 @@ extension NSObject {
         }
     }
     
+    // MARK: iOS 9 didReceiveRemoteNotification
     func leanplum_application_ios9(_ application: UIApplication,
                                      didReceiveRemoteNotification userInfo: [AnyHashable : Any],
                                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
@@ -112,6 +115,7 @@ extension NSObject {
         }
     }
     
+    // MARK: - UserNotificationCenter
     @objc @available(iOS 10.0, *)
     func leanplum_userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         LeanplumUtils.lpLog(type: .debug, format: "Called swizzled didReceiveNotificationResponse:withCompletionHandler")
@@ -181,6 +185,7 @@ extension NSObject {
         Leanplum.notificationsManager().notificationReceived(userInfo: notification.request.content.userInfo, isForeground: true)
     }
     
+    // MARK: - didReceive Local Notification
     @objc func leanplum_application(_ application: UIApplication, didReceive notification: UILocalNotification) {
         LeanplumUtils.lpLog(type: .debug, format: "Called swizzled application:didReceive:localNotification %d", UIApplication.shared.applicationState.rawValue)
         
@@ -204,6 +209,7 @@ extension NSObject {
         }
     }
     
+    // MARK: - didRegister Notification Settings
     @objc func leanplum_application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
         Leanplum.notificationsManager().didRegister(notificationSettings)
         

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/UNNotificationSettings+LPUtil.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/UNNotificationSettings+LPUtil.swift
@@ -28,7 +28,6 @@ extension UNNotificationSettings {
             return 0
         }
         
-        //
         // Authorization Status Enabled
         if settings.soundSetting == .enabled {
             result |= UNAuthorizationOptions.sound.rawValue

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumNotificationsManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumNotificationsManagerTest.swift
@@ -235,10 +235,10 @@ class LeanplumNotificationsManagerTest: XCTestCase {
      * Tests mute inside app correctly mutes notifications
      */
     func test_mute_inside_app() {
-        XCTAssertFalse(LeanplumUtils.isMuted(LeanplumNotificationsManagerTest.userInfo))
-        XCTAssertTrue(LeanplumUtils.isMuted(userInfoNoActionMuteInsideTrue))
-        XCTAssertTrue(LeanplumUtils.isMuted(userInfoNoActionMuteInsideFalse))
-        XCTAssertTrue(LeanplumUtils.isMuted(userInfoActionOpenURLMuteInsideTrue))
+        XCTAssertFalse(Leanplum.notificationsManager().isMuted(LeanplumNotificationsManagerTest.userInfo))
+        XCTAssertTrue(Leanplum.notificationsManager().isMuted(userInfoNoActionMuteInsideTrue))
+        XCTAssertTrue(Leanplum.notificationsManager().isMuted(userInfoNoActionMuteInsideFalse))
+        XCTAssertTrue(Leanplum.notificationsManager().isMuted(userInfoActionOpenURLMuteInsideTrue))
     }
     
     // MARK: Tests Delivery Tracking
@@ -298,7 +298,7 @@ class LeanplumNotificationsManagerTest: XCTestCase {
             XCTAssertEqual(eventParams[LP_KEY_PUSH_METRIC_MESSAGE_ID],
                            LeanplumUtils.messageIdFromUserInfo(LeanplumNotificationsManagerTest.userInfo))
             XCTAssertEqual(eventParams[LP_KEY_PUSH_METRIC_OCCURRENCE_ID],
-                           LeanplumUtils.getNotificationId(LeanplumNotificationsManagerTest.userInfo))
+                           Leanplum.notificationsManager().getNotificationId(LeanplumNotificationsManagerTest.userInfo))
             XCTAssertEqual(Double(eventParams[LP_KEY_PUSH_METRIC_SENT_TIME]!),
                            LeanplumNotificationsManagerTest.userInfo[LP_KEY_PUSH_SENT_TIME] as? Double)
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Structural changes

## Implementation
Reorganize the methods inside the classes, add marks for easier navigation.
Move some utils method from `LeanplumUtils` to `LeanplumNotificationsManager+Utils` extension

## Testing steps

## Is this change backwards-compatible?
Yes