### PR TITLE
Do not use OnAction for Local Notifications

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Features/Actions/LPActionManager.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Features/Actions/LPActionManager.m
@@ -87,7 +87,6 @@ static long WEEK_SECONDS;
 - (id)init
 {
     if (self = [super init]) {
-        [[LPLocalNotificationsManager sharedManager] listenForLocalNotifications];
         _sessionOccurrences = [NSMutableDictionary dictionary];
         _messageImpressionOccurrences = [NSMutableDictionary dictionary];
         _messageTriggerOccurrences = [NSMutableDictionary dictionary];

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -1914,13 +1914,14 @@ void leanplumExceptionHandler(NSException *exception);
                 }
                 if ([LP_PUSH_NOTIFICATION_ACTION isEqualToString:[actionContext actionName]]) {
                     [[LPLocalNotificationsManager sharedManager] scheduleLocalNotification:actionContext];
-                }
-                [self triggerAction:actionContext handledBlock:^(BOOL success) {
-                    if (success) {
-                        [[LPInternalState sharedState].actionManager
+                } else {
+                    [self triggerAction:actionContext handledBlock:^(BOOL success) {
+                        if (success) {
+                            [[LPInternalState sharedState].actionManager
                              recordMessageImpression:[actionContext messageId]];
-                    }
-                }];
+                        }
+                    }];
+                }
             }
         }
     }

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -1858,17 +1858,10 @@ void leanplumExceptionHandler(NSException *exception);
 
             // Make sure we cancel before matching in case the criteria overlap.
             if (result.matchedUnlessTrigger) {
-                NSString *cancelActionName = [@"__Cancel" stringByAppendingString:actionType];
-                LPActionContext *context = [LPActionContext actionContextWithName:cancelActionName
-                                                                             args:@{}
-                                                                        messageId:messageId];
-                [self triggerAction:context handledBlock:^(BOOL success) {
-                    if (success) {
-                        // Track cancel.
-                        [Leanplum track:@"Cancel" withValue:0.0 andInfo:nil
-                                andArgs:@{LP_PARAM_MESSAGE_ID: messageId} andParameters:nil];
-                    }
-                }];
+                // Currently Unless Trigger is possible for Local Notifications only
+                if ([LP_PUSH_NOTIFICATION_ACTION isEqualToString:actionType]) {
+                    [[LPLocalNotificationsManager sharedManager] cancelLocalNotification:messageId];
+                }
             }
             if (result.matchedTrigger) {
                 [[LPInternalState sharedState].actionManager recordMessageTrigger:internalMessageId];
@@ -1919,14 +1912,13 @@ void leanplumExceptionHandler(NSException *exception);
                     LPLog(LPDebug, @"Local IAM caps reached, suppressing messageId=%@", [actionContext messageId]);
                     continue;
                 }
+                if ([LP_PUSH_NOTIFICATION_ACTION isEqualToString:[actionContext actionName]]) {
+                    [[LPLocalNotificationsManager sharedManager] scheduleLocalNotification:actionContext];
+                }
                 [self triggerAction:actionContext handledBlock:^(BOOL success) {
                     if (success) {
-                        if ([LP_PUSH_NOTIFICATION_ACTION isEqualToString:[actionContext actionName]]) {
-                            [[LPInternalState sharedState].actionManager recordLocalPushImpression:[actionContext messageId]];
-                        } else {
-                            [[LPInternalState sharedState].actionManager
+                        [[LPInternalState sharedState].actionManager
                              recordMessageImpression:[actionContext messageId]];
-                        }
                     }
                 }];
             }

--- a/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.h
@@ -8,11 +8,13 @@
 
 #import <UIKit/UIKit.h>
 NS_ASSUME_NONNULL_BEGIN
+@class LPActionContext;
 
 @interface LPLocalNotificationsManager : NSObject
 
 + (LPLocalNotificationsManager *)sharedManager;
-- (void)listenForLocalNotifications;
+- (void)scheduleLocalNotification:(LPActionContext *)context;
+- (void)cancelLocalNotification:(NSString *)context;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
@@ -3,7 +3,7 @@
 //  Leanplum-iOS-Location
 //
 //  Created by Dejan Krstevski on 12.05.20.
-//  Copyright © 2020 Leanplum. All rights reserved.
+//  Copyright © 2021 Leanplum. All rights reserved.
 //
 
 #import "LPLocalNotificationsManager.h"
@@ -11,6 +11,10 @@
 #import "LPNotificationsConstants.h"
 #import <UserNotifications/UNUserNotificationCenter.h>
 #import <Leanplum/Leanplum-Swift.h>
+
+@interface LPLocalNotificationsManager (Private)
+- (BOOL)schedule:(LPActionContext *)context;
+@end
 
 @implementation LPLocalNotificationsManager
 
@@ -24,203 +28,213 @@
     return _sharedManager;
 }
 
-- (void)listenForLocalNotifications
+- (void)scheduleLocalNotification:(LPActionContext *)context
 {
-    [Leanplum onAction:LP_PUSH_NOTIFICATION_ACTION invoke:^BOOL(LPActionContext *context) {
-        LP_END_USER_CODE
-        UIApplication *app = [UIApplication sharedApplication];
+    if ([self schedule:context]) {
+        [[LPInternalState sharedState].actionManager recordLocalPushImpression:[context messageId]];
+    }
+}
 
-        BOOL contentAvailable = [context boolNamed:@"iOS options.Preload content"];
-        NSString *message = [context stringNamed:@"Message"];
+- (BOOL)schedule:(LPActionContext *)context
+{
+    LP_END_USER_CODE
+    UIApplication *app = [UIApplication sharedApplication];
 
-        if (![self shouldSendNotificationForMessage:message contentAvailable:contentAvailable])
-        {
-            return NO;
-        }
+    BOOL contentAvailable = [context boolNamed:@"iOS options.Preload content"];
+    NSString *message = [context stringNamed:@"Message"];
 
-        NSString *messageId = context.messageId;
+    if (![self shouldSendNotificationForMessage:message contentAvailable:contentAvailable])
+    {
+        return NO;
+    }
 
-        NSDictionary *messageConfig = [LPVarCache sharedCache].messageDiffs[messageId];
-        
-        NSNumber *countdown = messageConfig[@"countdown"];
-        if (context.isPreview) {
-            countdown = @(5.0);
-        }
-        if (![countdown.class isSubclassOfClass:NSNumber.class]) {
-            LPLog(LPDebug, @"Invalid notification countdown: %@", countdown);
-            return NO;
-        }
-        int countdownSeconds = [countdown intValue];
-        NSDate *eta = [[NSDate date] dateByAddingTimeInterval:countdownSeconds];
+    NSString *messageId = context.messageId;
 
-        if ([self shouldDiscard:eta context:context])
-        {
-            return NO;
-        }
-        
-        NSDictionary *userInfo = [context dictionaryNamed:@"Advanced options.Data"];
-        NSString *openAction = [context stringNamed:LP_VALUE_DEFAULT_PUSH_ACTION];
-        BOOL muteInsideApp = [context boolNamed:@"Advanced options.Mute inside app"];
-        NSString *sound = [context stringNamed:@"iOS options.Sound"];
-        NSString *badge = [context stringNamed:@"iOS options.Badge"];
-        NSString *category = [context stringNamed:@"iOS options.Category"];
+    NSDictionary *messageConfig = [LPVarCache sharedCache].messageDiffs[messageId];
+    
+    NSNumber *countdown = messageConfig[@"countdown"];
+    if (context.isPreview) {
+        countdown = @(5.0);
+    }
+    if (![countdown.class isSubclassOfClass:NSNumber.class]) {
+        LPLog(LPDebug, @"Invalid notification countdown: %@", countdown);
+        return NO;
+    }
+    int countdownSeconds = [countdown intValue];
+    NSDate *eta = [[NSDate date] dateByAddingTimeInterval:countdownSeconds];
 
-        // Specify custom data for the notification
-        NSMutableDictionary *mutableInfo;
-        if (userInfo) {
-            mutableInfo = [userInfo mutableCopy];
+    if ([self shouldDiscard:eta context:context])
+    {
+        return NO;
+    }
+    
+    NSDictionary *userInfo = [context dictionaryNamed:@"Advanced options.Data"];
+    NSString *openAction = [context stringNamed:LP_VALUE_DEFAULT_PUSH_ACTION];
+    BOOL muteInsideApp = [context boolNamed:@"Advanced options.Mute inside app"];
+    NSString *sound = [context stringNamed:@"iOS options.Sound"];
+    NSString *badge = [context stringNamed:@"iOS options.Badge"];
+    NSString *category = [context stringNamed:@"iOS options.Category"];
+
+    // Specify custom data for the notification
+    NSMutableDictionary *mutableInfo;
+    if (userInfo) {
+        mutableInfo = [userInfo mutableCopy];
+    } else {
+        mutableInfo = [NSMutableDictionary dictionary];
+    }
+    
+    // Adding body message manually.
+    mutableInfo[@"aps"] = @{@"alert":@{@"body": message ?: @""} };
+    
+    // Set unique occurrence id
+    mutableInfo[LP_KEY_PUSH_OCCURRENCE_ID] = [[[NSUUID UUID] UUIDString] lowercaseString];
+    
+    // Set local notification flag
+    mutableInfo[LP_KEY_LOCAL_NOTIF] = @YES;
+
+    // Specify open action
+    if (openAction) {
+        if (muteInsideApp) {
+            mutableInfo[LP_KEY_PUSH_MUTE_IN_APP] = messageId;
         } else {
-            mutableInfo = [NSMutableDictionary dictionary];
+            mutableInfo[LP_KEY_PUSH_MESSAGE_ID] = messageId;
         }
-        
-        // Adding body message manually.
-        mutableInfo[@"aps"] = @{@"alert":@{@"body": message ?: @""} };
-        
-        // Set unique occurrence id
-        mutableInfo[LP_KEY_PUSH_OCCURRENCE_ID] = [[[NSUUID UUID] UUIDString] lowercaseString];
-        
-        // Set local notification flag
-        mutableInfo[LP_KEY_LOCAL_NOTIF] = @YES;
-
-        // Specify open action
-        if (openAction) {
-            if (muteInsideApp) {
-                mutableInfo[LP_KEY_PUSH_MUTE_IN_APP] = messageId;
-            } else {
-                mutableInfo[LP_KEY_PUSH_MESSAGE_ID] = messageId;
-            }
+    } else {
+        if (muteInsideApp) {
+            mutableInfo[LP_KEY_PUSH_NO_ACTION_MUTE] = messageId;
         } else {
-            if (muteInsideApp) {
-                mutableInfo[LP_KEY_PUSH_NO_ACTION_MUTE] = messageId;
-            } else {
-                mutableInfo[LP_KEY_PUSH_NO_ACTION] = messageId;
-            }
+            mutableInfo[LP_KEY_PUSH_NO_ACTION] = messageId;
+        }
+    }
+    
+    if (@available(iOS 10.0, *)) {
+        UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+        
+        if (message) {
+            content.body = message;
+        } else {
+            content.body = LP_VALUE_DEFAULT_PUSH_MESSAGE;
         }
         
-        if (@available(iOS 10.0, *)) {
-            UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-            
-            if (message) {
-                content.body = message;
-            } else {
-                content.body = LP_VALUE_DEFAULT_PUSH_MESSAGE;
+        if (category) {
+            content.categoryIdentifier = category;
+        }
+        
+        if (sound) {
+            content.sound = [UNNotificationSound soundNamed:sound];
+        } else {
+            content.sound = [UNNotificationSound defaultSound];
+        }
+
+        if (badge) {
+            content.badge = [NSNumber numberWithInt:[badge intValue]];
+        }
+
+        content.userInfo = mutableInfo;
+        
+        NSDateComponents *dateComponenets = [[NSDateComponents alloc] init];
+        [dateComponenets setSecond:countdownSeconds];
+        UNCalendarNotificationTrigger *trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponenets repeats:NO];
+        
+        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:messageId content:content trigger:trigger];
+        
+        [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
+            if (error) {
+                LPLog(LPError, error.localizedDescription);
             }
-            
+        }];
+    } else {
+        // Fallback on earlier versions
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        UILocalNotification *localNotif = [[UILocalNotification alloc] init];
+        localNotif.fireDate = eta;
+        localNotif.timeZone = [NSTimeZone defaultTimeZone];
+        if (message) {
+            localNotif.alertBody = message;
+        } else {
+            localNotif.alertBody = LP_VALUE_DEFAULT_PUSH_MESSAGE;
+        }
+        localNotif.alertAction = @"View";
+
+        if ([localNotif respondsToSelector:@selector(setCategory:)]) {
             if (category) {
-                content.categoryIdentifier = category;
+                localNotif.category = category;
             }
-            
-            if (sound) {
-                content.sound = [UNNotificationSound soundNamed:sound];
-            } else {
-                content.sound = [UNNotificationSound defaultSound];
-            }
+        }
 
-            if (badge) {
-                content.badge = [NSNumber numberWithInt:[badge intValue]];
-            }
-
-            content.userInfo = mutableInfo;
-            
-            NSDateComponents *dateComponenets = [[NSDateComponents alloc] init];
-            [dateComponenets setSecond:countdownSeconds];
-            UNCalendarNotificationTrigger *trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponenets repeats:NO];
-            
-            UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:messageId content:content trigger:trigger];
-            
-            [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
-                if (error) {
-                    LPLog(LPError, error.localizedDescription);
-                }
-            }];
-            
+        if (sound) {
+            localNotif.soundName = sound;
         } else {
-            // Fallback on earlier versions
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            UILocalNotification *localNotif = [[UILocalNotification alloc] init];
-            localNotif.fireDate = eta;
-            localNotif.timeZone = [NSTimeZone defaultTimeZone];
-            if (message) {
-                localNotif.alertBody = message;
-            } else {
-                localNotif.alertBody = LP_VALUE_DEFAULT_PUSH_MESSAGE;
-            }
-            localNotif.alertAction = @"View";
+            localNotif.soundName = UILocalNotificationDefaultSoundName;
+        }
 
-            if ([localNotif respondsToSelector:@selector(setCategory:)]) {
-                if (category) {
-                    localNotif.category = category;
-                }
-            }
+        if (badge) {
+            localNotif.applicationIconBadgeNumber = [badge intValue];
+        }
 
-            if (sound) {
-                localNotif.soundName = sound;
-            } else {
-                localNotif.soundName = UILocalNotificationDefaultSoundName;
-            }
+        localNotif.userInfo = mutableInfo;
 
-            if (badge) {
-                localNotif.applicationIconBadgeNumber = [badge intValue];
-            }
-
-            localNotif.userInfo = mutableInfo;
-
-            // Schedule the notification
-            [app scheduleLocalNotification:localNotif];
+        // Schedule the notification
+        [app scheduleLocalNotification:localNotif];
 #pragma clang diagnostic pop
-        }
-        
-        if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
-            LPLog(LPInfo, @"Scheduled notification");
-        }
-        LP_BEGIN_USER_CODE
-        return YES;
-    }];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [Leanplum onAction:@"__Cancel__Push Notification" invoke:^BOOL(LPActionContext *context) {
-        LP_END_USER_CODE
-        UIApplication *app = [UIApplication sharedApplication];
-        NSArray *notifications = [app scheduledLocalNotifications];
-        if (@available(iOS 10.0, *)) {
-            __block BOOL didCancel = NO;
-            dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
-            [UNUserNotificationCenter.currentNotificationCenter getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
-                for (UNNotificationRequest *request in requests) {
-                    NSString *messageId = [LeanplumUtils messageIdFromUserInfo:[request.content userInfo]];
-                    if ([messageId isEqualToString:context.messageId]) {
-                        [UNUserNotificationCenter.currentNotificationCenter removePendingNotificationRequestsWithIdentifiers:@[request.identifier]];
-                        if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
-                            LPLog(LPInfo, @"Cancelled notification");
-                        }
-                        didCancel = YES;
-                    }
-                }
-                dispatch_semaphore_signal(semaphor);
-            }];
-            dispatch_time_t waitTime = dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC);
-            dispatch_semaphore_wait(semaphor, waitTime);
-            LP_BEGIN_USER_CODE
-            return didCancel;
-        } else {
-            // Fallback on earlier versions
-            BOOL didCancel = NO;
-            for (UILocalNotification *notification in notifications) {
-                NSString *messageId = [LeanplumUtils messageIdFromUserInfo:[notification userInfo]];
-                if ([messageId isEqualToString:context.messageId]) {
-                    [app cancelLocalNotification:notification];
+    }
+    
+    if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
+        LPLog(LPInfo, @"Scheduled notification");
+    }
+    LP_BEGIN_USER_CODE
+    return YES;
+}
+
+- (void)cancelLocalNotification:(NSString *)messageId
+{
+    LP_END_USER_CODE
+    UIApplication *app = [UIApplication sharedApplication];
+    NSArray *notifications = [app scheduledLocalNotifications];
+    BOOL cancelled = NO;
+    if (@available(iOS 10.0, *)) {
+        __block BOOL didCancel = NO;
+        dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
+        [UNUserNotificationCenter.currentNotificationCenter getPendingNotificationRequestsWithCompletionHandler:^(NSArray<UNNotificationRequest *> * _Nonnull requests) {
+            for (UNNotificationRequest *request in requests) {
+                NSString *notificationMessageId = [LeanplumUtils messageIdFromUserInfo:[request.content userInfo]];
+                if ([notificationMessageId isEqualToString:messageId]) {
+                    [UNUserNotificationCenter.currentNotificationCenter removePendingNotificationRequestsWithIdentifiers:@[request.identifier]];
                     if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
                         LPLog(LPInfo, @"Cancelled notification");
                     }
                     didCancel = YES;
                 }
             }
-            LP_BEGIN_USER_CODE
-            return didCancel;
+            dispatch_semaphore_signal(semaphor);
+        }];
+        dispatch_time_t waitTime = dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC);
+        dispatch_semaphore_wait(semaphor, waitTime);
+        LP_BEGIN_USER_CODE
+        cancelled = didCancel;
+    } else {
+        // Fallback on earlier versions
+        BOOL didCancel = NO;
+        for (UILocalNotification *notification in notifications) {
+            NSString *notificationMessageId = [LeanplumUtils messageIdFromUserInfo:[notification userInfo]];
+            if ([notificationMessageId isEqualToString:messageId]) {
+                [app cancelLocalNotification:notification];
+                if ([LPConstantsState sharedState].isDevelopmentModeEnabled) {
+                    LPLog(LPInfo, @"Cancelled notification");
+                }
+                didCancel = YES;
+            }
         }
-    }];
-#pragma clang diagnostic pop
+        LP_BEGIN_USER_CODE
+        cancelled = didCancel;
+    }
+    
+    if (cancelled) {
+        // Track cancel
+        [Leanplum track:@"Cancel" withValue:0.0 andInfo:nil
+                andArgs:@{LP_PARAM_MESSAGE_ID: messageId} andParameters:nil];
+    }
 }
 
 #pragma clang diagnostic push

--- a/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Notifications/Local/LPLocalNotificationsManager.m
@@ -192,7 +192,7 @@
     LP_END_USER_CODE
     UIApplication *app = [UIApplication sharedApplication];
     NSArray *notifications = [app scheduledLocalNotifications];
-    BOOL cancelled = NO;
+    BOOL canceled = NO;
     if (@available(iOS 10.0, *)) {
         __block BOOL didCancel = NO;
         dispatch_semaphore_t semaphor = dispatch_semaphore_create(0);
@@ -212,7 +212,7 @@
         dispatch_time_t waitTime = dispatch_time(DISPATCH_TIME_NOW, 5.0 * NSEC_PER_SEC);
         dispatch_semaphore_wait(semaphor, waitTime);
         LP_BEGIN_USER_CODE
-        cancelled = didCancel;
+        canceled = didCancel;
     } else {
         // Fallback on earlier versions
         BOOL didCancel = NO;
@@ -227,10 +227,10 @@
             }
         }
         LP_BEGIN_USER_CODE
-        cancelled = didCancel;
+        canceled = didCancel;
     }
     
-    if (cancelled) {
+    if (canceled) {
         // Track cancel
         [Leanplum track:@"Cancel" withValue:0.0 andInfo:nil
                 andArgs:@{LP_PARAM_MESSAGE_ID: messageId} andParameters:nil];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-595](https://leanplum.atlassian.net/browse/SDK-595)
People Involved   | @nzagorchev 

## Background
Move away from using `onAction` and `triggerAction` for Local Notifications schedule and cancel.

## Implementation

## Testing steps

## Is this change backwards-compatible?
