### PR TITLE
added time sensitive as push type

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/UNNotificationSettings+LPUtil.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/UNNotificationSettings+LPUtil.swift
@@ -44,8 +44,10 @@ extension UNNotificationSettings {
         if settings.notificationCenterSetting == .enabled {
             result |= (1 << 4)
         }
-        if settings.alertStyle != .none {
-            result |= (1 << 5)
+        if #available(iOS 15.0, *) {
+            if settings.timeSensitiveSetting == .enabled {
+                result |= (1 << 5)
+            }
         }
         
         return result


### PR DESCRIPTION
## Background
adding support for time sensitive push notifications.
Sending this to backend so that it is aware if this setting is enabled
## Implementation
because there is no need for alertStyle, because it is not making difference if it is a banner or alert (alertSetting is covering this), we decided to send time sensitive setting instead of alertStyle
## Testing steps

## Is this change backwards-compatible?
