### PR TITLE
Remove iOS version check func

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -336,13 +336,6 @@ void leanplumExceptionHandler(NSException *exception);
     LP_END_TRY
 }
 
-+ (void)setDeviceVersion:(NSString *)deviceVersion
-{
-    LP_TRY
-    [Leanplum notificationsManager].proxy.deviceVersion = deviceVersion;
-    LP_END_TRY
-}
-
 + (void)setAppId:(NSString *)appId withProductionKey:(NSString *)accessKey
 {
     if ([LPUtils isNullOrEmpty:appId]) {

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -257,8 +257,6 @@ NS_SWIFT_NAME(setAppId(_:productionKey:));
  */
 + (void)setAppVersion:(NSString *)appVersion;
 
-+ (void)setDeviceVersion:(NSString *)deviceVersion;
-
 /**
  * Syncs resources between Leanplum and the current app.
  * You should only call this once, and before {@link start}.

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
@@ -96,9 +96,8 @@ import Foundation
     // MARK: Notification Open
     @objc(notificationOpened:action:)
     func notificationOpened(userInfo: [AnyHashable : Any], action: String = LP_VALUE_DEFAULT_PUSH_ACTION) {
-        LeanplumUtils.lpLog(type: .debug, format: "Notification Opened Id: %@", Leanplum.notificationsManager().getNotificationId(userInfo))
-        
         guard let messageId = LeanplumUtils.messageIdFromUserInfo(userInfo) else { return }
+        LeanplumUtils.lpLog(type: .debug, format: "Notification Opened MessageId: %@", messageId)
         
         let isDefaultAction = action == LP_VALUE_DEFAULT_PUSH_ACTION
         let actionName = isDefaultAction ? action : "iOS options.Custom actions.\(action)"
@@ -141,7 +140,7 @@ import Foundation
     // MARK: Notification Received
     func notificationReceived(userInfo: [AnyHashable : Any], isForeground: Bool) {
         guard let messageId = LeanplumUtils.messageIdFromUserInfo(userInfo) else { return }
-        LeanplumUtils.lpLog(type: .debug, format: "Notification received on %@. MessageId: @%, Id: %@", isForeground ? "Foreground" : "Background", messageId, Leanplum.notificationsManager().getNotificationId(userInfo))
+        LeanplumUtils.lpLog(type: .debug, format: "Notification received - %@. MessageId: @%", isForeground ? "Foreground" : "Background", messageId)
         
         trackDelivery(userInfo: userInfo)
         if isForeground {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
@@ -86,7 +86,6 @@ public class LeanplumPushNotificationsProxy: NSObject {
     
     // MARK: - Methods Swizzling Disabled
     @objc public func applicationDidFinishLaunching(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-        LeanplumUtils.lpLog(type: .debug, format: "Called applicationDidFinishLaunching: %@, state %d", launchOptions ?? [:], UIApplication.shared.applicationState.rawValue)
         if let launchOptions = launchOptions {
             self.leanplum_applicationDidFinishLaunching(launchOptions: launchOptions)
         }
@@ -214,7 +213,7 @@ public class LeanplumPushNotificationsProxy: NSObject {
             swizzleUserNotificationDidReceiveNotificationResponseWithCompletionHandler()
             swizzleUserNotificationWillPresentNotificationWithCompletionHandler()
         } else {
-            LeanplumUtils.lpLog(type: .info, format: "\(userNotificationDelegateName) is not set.")
+            LeanplumUtils.lpLog(type: .debug, format: "\(userNotificationDelegateName) is not set.")
             let userNotificationCenterDelegateProtocol = objc_getProtocol(userNotificationDelegateName)
             if let notifProtocol = userNotificationCenterDelegateProtocol, let applicationDelegate = appDelegate {
                 var conforms = applicationDelegate.conforms(to: notifProtocol)
@@ -224,7 +223,7 @@ public class LeanplumPushNotificationsProxy: NSObject {
                 }
                 
                 if conforms, let notifDelegate = applicationDelegate as? UNUserNotificationCenterDelegate {
-                    LeanplumUtils.lpLog(type: .info, format: "Setting \(userNotificationDelegateName).")
+                    LeanplumUtils.lpLog(type: .debug, format: "Setting \(userNotificationDelegateName).")
                     UNUserNotificationCenter.current().delegate = notifDelegate
                     swizzleUserNotificationDidReceiveNotificationResponseWithCompletionHandler()
                     swizzleUserNotificationWillPresentNotificationWithCompletionHandler()
@@ -259,7 +258,6 @@ public class LeanplumPushNotificationsProxy: NSObject {
             LeanplumUtils.lpLog(type: .info, format: "Method swizzling is disabled, make sure to manually call Leanplum methods.")
             return
         }
-        LeanplumUtils.lpLog(type: .info, format: "Method swizzling started.")
         
         if !isCustomAppDelegateUsed {
             ensureOriginalAppDelegate()
@@ -269,8 +267,7 @@ public class LeanplumPushNotificationsProxy: NSObject {
         swizzleTokenMethods()
         
         // Try to swizzle UNUserNotificationCenterDelegate methods
-        //        if #available(iOS 10.0, *) {
-        if isIOSVersionGreaterThanOrEqual("10"), #available(iOS 10.0, *) {
+        if #available(iOS 10.0, *) {
             // Client's UNUserNotificationCenter delegate needs to be set before Leanplum starts
             swizzleUNUserNotificationCenterMethods()
             swizzleApplicationDidReceiveFetchCompletionHandler()
@@ -333,10 +330,5 @@ public class LeanplumPushNotificationsProxy: NSObject {
                 }
             }
         }
-    }
-    
-    func isIOSVersionGreaterThanOrEqual(_ version:String) -> Bool {
-        let currentVersion = UIDevice.current.systemVersion
-        return (deviceVersion ?? currentVersion).compare(version,options: .numeric) != .orderedAscending
     }
 }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
@@ -12,7 +12,6 @@ public class LeanplumPushNotificationsProxy: NSObject {
     // MARK: - Initialization
     internal override init() {}
     
-    @objc public var deviceVersion:String?
     // TimeInterval when application was resumed
     // Used for iOS 9 notifications when state changes from inactive to active
     @objc public var resumedTimeInterval:Double = 0

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
@@ -35,7 +35,8 @@ extension NSObject {
     @objc func leanplum_application(_ application: UIApplication,
                                      didReceiveRemoteNotification userInfo: [AnyHashable : Any],
                                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        LeanplumUtils.lpLog(type: .debug, format: "Called swizzled didReceiveRemoteNotification:fetchCompletionHandler")
+        LeanplumUtils.lpLog(type: .debug,
+                            format: "Called swizzled application:didReceiveRemoteNotification:fetchCompletionHandler AppState: %d", UIApplication.shared.applicationState.rawValue)
         
         defer {
             // Call overridden method
@@ -70,7 +71,7 @@ extension NSObject {
         
         let state = UIApplication.shared.applicationState
         // Call notification received or perform action
-        if Leanplum.notificationsManager().proxy.isIOSVersionGreaterThanOrEqual("10") { //, #available(iOS 10, *) {
+        if #available(iOS 10, *) {
             // Open notification will be handled by userNotificationCenter:didReceive or
             // application:didFinishLaunchingWithOptions
             // Receiving of notification when app is running on foreground is handled by userNotificationCenter:willPresent
@@ -90,7 +91,6 @@ extension NSObject {
                                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         // iOS 9
         let state = UIApplication.shared.applicationState
-        LeanplumUtils.lpLog(type: .debug, format: "didReceiveRemoteNotification:fetchCompletionHandler: %d", state.rawValue)
         // Notification was not handled by application:didFinishLaunchingWithOptions
         if !Leanplum.notificationsManager().proxy.isEqualToHandledNotification(userInfo: userInfo) {
         if  state == .inactive {
@@ -118,7 +118,8 @@ extension NSObject {
     // MARK: - UserNotificationCenter
     @objc @available(iOS 10.0, *)
     func leanplum_userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        LeanplumUtils.lpLog(type: .debug, format: "Called swizzled didReceiveNotificationResponse:withCompletionHandler")
+        LeanplumUtils.lpLog(type: .debug,
+                            format: "Called swizzled userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler")
         
         let userInfo = response.notification.request.content.userInfo
         defer {
@@ -150,8 +151,6 @@ extension NSObject {
         // Handle UNNotificationDefaultActionIdentifier and Custom Actions
         if response.actionIdentifier != UNNotificationDismissActionIdentifier {
             let notifWasOpenedFromStart = Leanplum.notificationsManager().proxy.isEqualToHandledNotification(userInfo: userInfo) && Leanplum.notificationsManager().proxy.notificationOpenedFromStart
-            
-            LeanplumUtils.lpLog(type: .debug, format: "notificationOpenedFromStart \(notifWasOpenedFromStart)")
             if !notifWasOpenedFromStart {
                 // Open Notification action
                 if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
@@ -166,7 +165,8 @@ extension NSObject {
     
     @objc @available(iOS 10.0, *)
     func leanplum_userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        LeanplumUtils.lpLog(type: .debug, format: "Called swizzled willPresentNotification:withCompletionHandler")
+        LeanplumUtils.lpLog(type: .debug,
+                            format: "Called swizzled userNotificationCenter:willPresentNotification:withCompletionHandler")
         
         defer {
             // Call overridden method
@@ -187,7 +187,7 @@ extension NSObject {
     
     // MARK: - didReceive Local Notification
     @objc func leanplum_application(_ application: UIApplication, didReceive notification: UILocalNotification) {
-        LeanplumUtils.lpLog(type: .debug, format: "Called swizzled application:didReceive:localNotification %d", UIApplication.shared.applicationState.rawValue)
+        LeanplumUtils.lpLog(type: .debug, format: "Called swizzled application:didReceive:localNotification")
         
         defer {
             // Call overridden method


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

Remove `isIOSVersionGreaterThanOrEqual` function used for testing.
Improve log messages.

## Background

## Implementation

## Testing steps

## Is this change backwards-compatible?
