### PR TITLE
Expose push enable methods

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -2804,6 +2804,16 @@ void leanplumExceptionHandler(NSException *exception)
     return [[LPActionManager sharedManager] shouldSuppressMessages];
 }
 
++ (void)enablePushNotifications
+{
+    [[Leanplum notificationsManager] enableSystemPush];
+}
+
++ (void)enableProvisionalPushNotifications
+{
+    [[Leanplum notificationsManager] enableProvisionalPush];
+}
+
 - (void) dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[Leanplum notificationsManager].proxy removeDidFinishLaunchingObserver];

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -412,7 +412,7 @@ void leanplumExceptionHandler(NSException *exception);
         
         //Clean UserDefaults before changing deviceId because it is used to generate key
         [[Leanplum notificationsManager] removePushToken];
-        [[Leanplum notificationsManager] removeNotificaitonSettings];
+        [[Leanplum notificationsManager] removeNotificationSettings];
         
         // Change the LPAPIConfig after getting the push token and settings
         // and after cleaning UserDefaults
@@ -1100,7 +1100,7 @@ void leanplumExceptionHandler(NSException *exception);
                 usingBlock:^(NSNotification *notification) {
                     RETURN_IF_NOOP;
                     LP_TRY
-                    //call update notificaiton settings to check if values are changed.
+                    //call update notification settings to check if values are changed.
                     //if they are changed the new valeus will be updated to server as well
                     [[Leanplum notificationsManager] updateNotificationSettings];
         

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -816,6 +816,16 @@ NS_SWIFT_NAME(setDeviceLocation(latitude:longitude:city:region:country:type:));
  */
 + (nullable LPSecuredVars *)securedVars;
 
+/**
+ Enables system push notifications through Leanplum SDK
+ */
++ (void)enablePushNotifications;
+
+/**
+ Enables provisional push notifications through Leanplum SDK
+ */
++ (void)enableProvisionalPushNotifications API_AVAILABLE(ios(12.0));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager+Utils.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager+Utils.swift
@@ -32,9 +32,9 @@ import Foundation
                     LeanplumUtils.lpLog(type: .error, format: "Error: %@", error.localizedDescription)
                 }
                 
-                //Register for remote notificaiton to create and send push token to server
+                //Register for remote notification to create and send push token to server
                 //no metter if the request was granted or has error, push token will be generated
-                //and later if user decides to go into the settings and enables push notificaitons
+                //and later if user decides to go into the settings and enables push notifications
                 //we will have token and will only update push types
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
@@ -35,7 +35,7 @@ import Foundation
         notificationSettings.save(settings)       
     }
     
-    @objc public func removeNotificaitonSettings() {
+    @objc public func removeNotificationSettings() {
         notificationSettings.removeSettings()
     }
     

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumPushNotificationSettingsTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LeanplumPushNotificationSettingsTest.swift
@@ -13,11 +13,11 @@ import XCTest
 @available(iOS 10.0, *)
 class LeanplumPushNotificationSettingsTest: XCTestCase {
     
-    var notificaitonSettings: LeanplumNotificationSettings!
+    var notificationSettings: LeanplumNotificationSettings!
     
     override func setUp() {
         super.setUp()
-        notificaitonSettings = LeanplumNotificationSettings()
+        notificationSettings = LeanplumNotificationSettings()
     }
     
     override func tearDown() {
@@ -55,14 +55,14 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
     }
     
     func testSetUp() {
-        notificaitonSettings.setUp()
-        XCTAssertTrue(notificaitonSettings.updateSettings != nil)
+        notificationSettings.setUp()
+        XCTAssertTrue(notificationSettings.updateSettings != nil)
     }
     
     func testGetSettingsWhenAuthorizationStatusNotDetermined() {
         let expectation = expectation(description: "Test authorizationStatus notDetermined")
         UNNotificationSettings.fakeAuthorizationStatus = .notDetermined
-        notificaitonSettings.getSettings() { settings, areChanged in
+        notificationSettings.getSettings() { settings, areChanged in
             if let _ = settings[LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES] as? UInt {
                 fatalError()
             } else {
@@ -75,7 +75,7 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
     func testGetSettingsWhenAuthorizationStatusDenied() {
         let expectation = expectation(description: "Test authorizationStatus denied")
         UNNotificationSettings.fakeAuthorizationStatus = .denied
-        notificaitonSettings.getSettings() { settings, areChanged in
+        notificationSettings.getSettings() { settings, areChanged in
             if let types = settings[LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES] as? UInt {
                 if types == 0 {
                     expectation.fulfill()
@@ -88,7 +88,7 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
     func testGetSettingsWhenAuthorizationStatusAuthorized() {
         let expectation = expectation(description: "Test authorized")
         UNNotificationSettings.fakeAuthorizationStatus = .authorized
-        notificaitonSettings.getSettings() { settings, areChanged in
+        notificationSettings.getSettings() { settings, areChanged in
             if let types = settings[LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES] as? UInt {
                 if types == 63 {
                     expectation.fulfill()
@@ -102,7 +102,7 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
     func testGetSettingsWithProvisionalAuthorizationStatus() {
         let expectation = expectation(description: "Test provisional authorizationStatus")
         UNNotificationSettings.fakeAuthorizationStatus = .provisional
-        notificaitonSettings.getSettings() { settings, areChanged in
+        notificationSettings.getSettings() { settings, areChanged in
             if let types = settings[LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES] as? UInt {
                 if types == 64 {
                     expectation.fulfill()
@@ -115,24 +115,24 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
     func testSaveAndRemoveSettings() {
         let testSettings: [AnyHashable: Any] = [LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES: 7,
                             LP_PARAM_DEVICE_USER_NOTIFICATION_CATEGORIES: []]
-        notificaitonSettings.save(testSettings)
+        notificationSettings.save(testSettings)
         
-        guard let savedSettings = UserDefaults.standard.value(forKey: notificaitonSettings.leanplumUserNotificationSettingsKey()) as? [AnyHashable : Any] else {
+        guard let savedSettings = UserDefaults.standard.value(forKey: notificationSettings.leanplumUserNotificationSettingsKey()) as? [AnyHashable : Any] else {
             XCTFail("Settings are not saved")
             return
         }
         XCTAssertTrue(NSDictionary(dictionary: savedSettings).isEqual(to: testSettings))
         
-        notificaitonSettings.removeSettings()
+        notificationSettings.removeSettings()
         
-        XCTAssertNil(UserDefaults.standard.value(forKey: notificaitonSettings.leanplumUserNotificationSettingsKey()))
+        XCTAssertNil(UserDefaults.standard.value(forKey: notificationSettings.leanplumUserNotificationSettingsKey()))
     }
     
     func testWhenUpdateSettingsIsCalledItWillUpdateSettingsToServer() {
         setUp_request()
         //first remove settings from defaults
-        notificaitonSettings.removeSettings()
-        notificaitonSettings.setUp()
+        notificationSettings.removeSettings()
+        notificationSettings.setUp()
         //authorize settings to have push types
         UNNotificationSettings.fakeAuthorizationStatus = .authorized
         
@@ -149,18 +149,18 @@ class LeanplumPushNotificationSettingsTest: XCTestCase {
         }
         
         //calling updateSettings will trigger update settings to server
-        notificaitonSettings.updateSettings?()
+        notificationSettings.updateSettings?()
         
         wait(for: [expectation], timeout: 5)
         tearDown_request()
     }
 }
 
-protocol LeanplumNotificaitonSettingsProtocol {
+protocol LeanplumNotificationSettingsProtocol {
     func leanplumUserNotificationSettingsKey() -> String
 }
 
-extension LeanplumNotificationSettings: LeanplumNotificaitonSettingsProtocol {
+extension LeanplumNotificationSettings: LeanplumNotificationSettingsProtocol {
     func leanplumUserNotificationSettingsKey() -> String {
         guard let appId = LPAPIConfig.shared().appId, let userId = LPAPIConfig.shared().userId, let deviceId = LPAPIConfig.shared().deviceId else {
             fatalError()


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | 
People Involved   | @dejan2k 

## Background
Having option to enable push notifications and provisional push through the SDK
## Implementation
Adding methods in Leanplum class that will call corresponding methods from notificationManager
## Testing steps

## Is this change backwards-compatible?
