### PR TITLE
Completion handlers improvements

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -1595,7 +1595,7 @@ void leanplumExceptionHandler(NSException *exception);
     [blocks addObject:[block copy]];
     LP_END_TRY
 }
-
+#pragma mark Notifications Swizzling Disabled Methods
 + (void)applicationDidFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions
 {
     LP_TRY
@@ -1639,12 +1639,12 @@ void leanplumExceptionHandler(NSException *exception);
 }
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)userInfo
-              fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
 {
     LP_TRY
     if (![LPUtils isSwizzlingEnabled])
     {
-        [[Leanplum notificationsManager].proxy didReceiveRemoteNotificationWithUserInfo:userInfo fetchCompletionHandler:completionHandler];
+        void (^emptyBlock)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result) {};
+        [[Leanplum notificationsManager].proxy didReceiveRemoteNotificationWithUserInfo:userInfo fetchCompletionHandler:emptyBlock];
     }
     else
     {
@@ -1654,12 +1654,12 @@ void leanplumExceptionHandler(NSException *exception);
 }
 
 + (void)didReceiveNotificationResponse:(UNNotificationResponse *)response
-                 withCompletionHandler:(void (^)(void))completionHandler
 {
     LP_TRY
     if (![LPUtils isSwizzlingEnabled])
     {
-        [[Leanplum notificationsManager].proxy userNotificationCenterWithDidReceive:response withCompletionHandler:completionHandler];
+        void (^emptyBlock)(void) = ^{};
+        [[Leanplum notificationsManager].proxy userNotificationCenterWithDidReceive:response withCompletionHandler:emptyBlock];
     }
     else
     {
@@ -1669,12 +1669,12 @@ void leanplumExceptionHandler(NSException *exception);
 }
 
 + (void)willPresentNotification:(UNNotification *)notification
-          withCompletionHandler:(void(^)(UNNotificationPresentationOptions options))completionHandler
 {
     LP_TRY
     if (![LPUtils isSwizzlingEnabled])
     {
-        [[Leanplum notificationsManager].proxy userNotificationCenterWithWillPresent:notification withCompletionHandler:completionHandler];
+        void(^emptyBlock)(UNNotificationPresentationOptions) = ^(UNNotificationPresentationOptions options) {};
+        [[Leanplum notificationsManager].proxy userNotificationCenterWithWillPresent:notification withCompletionHandler:emptyBlock];
     }
     else
     {
@@ -1753,6 +1753,14 @@ void leanplumExceptionHandler(NSException *exception);
     LP_TRY
     [Leanplum notificationsManager].isPushDeliveryTrackingEnabled = enabled;
     LP_END_TRY
+}
+
+/**
+ * Sets the UNNotificationPresentationOptions to be used when Swizzling is enabled.
+ */
++ (void)setPushNotificationPresentationOption:(UNNotificationPresentationOptions)options
+{
+    [[[Leanplum notificationsManager] proxy] setPushNotificationPresentationOption:options];
 }
 
 + (void)addResponder:(id)responder withSelector:(SEL)selector forActionNamed:(NSString *)actionName

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -427,12 +427,21 @@ NS_SWIFT_NAME(deferMessagesWithActionNames(_:));
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 #pragma clang diagnostic pop
-+ (void)didReceiveRemoteNotification:(NSDictionary *)userInfo
-              fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-+ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0));
-+ (void)willPresentNotification:(UNNotification *)notification
-          withCompletionHandler:(void(^)(UNNotificationPresentationOptions options))completionHandler
-    API_AVAILABLE(ios(10.0));
+/**
+ * Call this method from application:didReceiveRemoteNotification:fetchCompletionHandler when Swizzling is Disabled.
+ * Call the completionHandler yourself.
+ */
++ (void)didReceiveRemoteNotification:(NSDictionary *)userInfo;
+/**
+ * Call this method from userNotificationCenter:didReceive:withCompletionHandler when Swizzling is Disabled.
+ * Call the completionHandler yourself.
+ */
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response API_AVAILABLE(ios(10.0));
+/**
+ * Call this method from userNotificationCenter:willPresent:withCompletionHandler when Swizzling is Disabled.
+ * Call the completionHandler yourself.
+ */
++ (void)willPresentNotification:(UNNotification *)notification API_AVAILABLE(ios(10.0));
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
@@ -441,6 +450,7 @@ NS_SWIFT_NAME(deferMessagesWithActionNames(_:));
 
 /**
  * Call this to handle custom actions for local notifications.
+ * Call the completionHandler yourself.
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -452,6 +462,7 @@ NS_SWIFT_NAME(deferMessagesWithActionNames(_:));
 
 /**
  * Call this to handle custom actions for remote notifications.
+ * Call the completionHandler yourself.
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
@@ -473,6 +484,8 @@ NS_SWIFT_NAME(deferMessagesWithActionNames(_:));
  * @see PUSH_DELIVERED_EVENT_NAME for the event name
  */
 + (void)setPushDeliveryTrackingEnabled:(BOOL)enabled;
+
++ (void)setPushNotificationPresentationOption:(UNNotificationPresentationOptions)options API_AVAILABLE(ios(10.0));
 
 /**
  * @{

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationSettings.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationSettings.swift
@@ -104,12 +104,12 @@ class LeanplumNotificationSettings {
             let types = settings.toInt()
             
             UNUserNotificationCenter.current().getNotificationCategories { categories in
-                var cate: [UNNotificationCategory] = []
+                var cate: [String] = []
                 for category in categories {
-                    cate.append(category)
+                    cate.append(category.identifier)
                 }
-                let sortedCategories = cate.sorted { (lhs: UNNotificationCategory, rhs: UNNotificationCategory) -> Bool in
-                    return lhs.identifier.caseInsensitiveCompare(rhs.identifier) == .orderedAscending
+                let sortedCategories = cate.sorted { (lhs: String, rhs: String) -> Bool in
+                    return lhs.caseInsensitiveCompare(rhs) == .orderedAscending
                 }
                 
                 let settings = [

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
@@ -140,7 +140,7 @@ import Foundation
     // MARK: Notification Received
     func notificationReceived(userInfo: [AnyHashable : Any], isForeground: Bool) {
         guard let messageId = LeanplumUtils.messageIdFromUserInfo(userInfo) else { return }
-        LeanplumUtils.lpLog(type: .debug, format: "Notification received - %@. MessageId: @%", isForeground ? "Foreground" : "Background", messageId)
+        LeanplumUtils.lpLog(type: .debug, format: "Notification received - %@. MessageId: %@", isForeground ? "Foreground" : "Background", messageId)
         
         trackDelivery(userInfo: userInfo)
         if isForeground {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumNotificationsManager.swift
@@ -100,13 +100,12 @@ import Foundation
         LeanplumUtils.lpLog(type: .debug, format: "Notification Opened MessageId: %@", messageId)
         
         let isDefaultAction = action == LP_VALUE_DEFAULT_PUSH_ACTION
-        let actionName = isDefaultAction ? action : "iOS options.Custom actions.\(action)"
         
         let downloadFilesAndRunAction: (ActionContext) -> () = { context in
             context.maybeDownloadFiles()
             // Wait for Leanplum start so action responders are registered
             Leanplum.onStartIssued {
-                context.runTrackedAction(name: actionName)
+                context.runTrackedAction(name: action)
             }
         }
         
@@ -116,15 +115,7 @@ import Foundation
                 args = [action: userInfo[LP_KEY_PUSH_ACTION] ?? ""]
             } else {
                 let customActions = userInfo[LP_KEY_PUSH_CUSTOM_ACTIONS] as? [AnyHashable : Any]
-                // Arguments must be nested, so ActionContext.getChildArgs: resolves the action
-                // ActionName is split by "." into components
-                args = [
-                    "iOS options": [
-                        "Custom actions": [
-                            action: customActions?[action]
-                        ]
-                    ]
-                ]
+                args = [action: customActions?[action] ?? ""]
             }
             let context = ActionContext.init(name: LP_PUSH_NOTIFICATION_ACTION, args: args, messageId: messageId)
             context.preventRealtimeUpdating = true

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/LeanplumPushNotificationsProxy.swift
@@ -24,7 +24,8 @@ public class LeanplumPushNotificationsProxy: NSObject {
     var isCustomAppDelegateUsed = false
     
     @available(iOS 10.0, *)
-    lazy var pushNotificationPresentationOption:UNNotificationPresentationOptions = [] // UNNotificationPresentationOptionNone
+    @objc
+    public lazy var pushNotificationPresentationOption:UNNotificationPresentationOptions = [] // UNNotificationPresentationOptionNone
     
     let userNotificationDelegateName = "UNUserNotificationCenterDelegate"
     

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/NSObject+Notifications.swift
@@ -173,6 +173,8 @@ extension NSObject {
             let selector = #selector(self.leanplum_userNotificationCenter(_:willPresent:withCompletionHandler:))
             if Leanplum.notificationsManager().proxy.swizzledUserNotificationCenterWillPresentNotificationWithCompletionHandler && self.responds(to: selector) {
                 self.leanplum_userNotificationCenter(center, willPresent: notification, withCompletionHandler: completionHandler)
+            } else {
+                completionHandler(Leanplum.notificationsManager().proxy.pushNotificationPresentationOption)
             }
         }
         

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/UIUserNotificationSettings+LPUtil.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/UIUserNotificationSettings+LPUtil.swift
@@ -22,7 +22,7 @@ extension UIUserNotificationSettings {
             return lhs.identifier?.caseInsensitiveCompare(rhs.identifier ?? "") == .orderedAscending
         }
         let settings = [
-            LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES: types,
+            LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES: types.rawValue,
             LP_PARAM_DEVICE_USER_NOTIFICATION_CATEGORIES: sortedCategories
         ] as [AnyHashable : Any]
         return settings

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/UIUserNotificationSettings+LPUtil.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/UIUserNotificationSettings+LPUtil.swift
@@ -10,16 +10,16 @@ import Foundation
 extension UIUserNotificationSettings {
     var dictionary: [AnyHashable: Any] {
         let types = self.types
-        var categories: [UIUserNotificationCategory] = []
+        var categories: [String] = []
         if let tmpCategories = self.categories {
             for category in tmpCategories {
-                if category.identifier != nil {
-                    categories.append(category)
+                if let categoryIdentifier = category.identifier {
+                    categories.append(categoryIdentifier)
                 }
             }
         }
-        let sortedCategories = categories.sorted { (lhs: UIUserNotificationCategory, rhs: UIUserNotificationCategory) -> Bool in
-            return lhs.identifier?.caseInsensitiveCompare(rhs.identifier ?? "") == .orderedAscending
+        let sortedCategories = categories.sorted { (lhs: String, rhs: String) -> Bool in
+            return lhs.caseInsensitiveCompare(rhs) == .orderedAscending
         }
         let settings = [
             LP_PARAM_DEVICE_USER_NOTIFICATION_TYPES: types.rawValue,


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-609](https://leanplum.atlassian.net/browse/SDK-609)
People Involved   | @nzagorchev 

## Background
Completion handlers should be executed by the client's app if Swizzling is Disabled.
Fix push types and categories for iOS 9
Improve custom push actions actionName (hence event name also).

## Implementation
Remove the handlers from the parameters of the methods.

## Testing steps

## Is this change backwards-compatible?
