### PR TITLE
Trigger observers that inbox is up to date after start

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -984,6 +984,9 @@ void leanplumExceptionHandler(NSException *exception);
 
         if ([response[LP_KEY_SYNC_INBOX] boolValue]) {
             [[self inbox] downloadMessages];
+        } else {
+            // Inbox is up to date, so inform observers
+            [[self inbox] triggerInboxChanged];
         }
 
         if ([response[LP_KEY_LOGGING_ENABLED] boolValue]) {


### PR DESCRIPTION
## Background

When `start` is called, `onInboxChanged` was not triggered if there was nothing to update form the server. After start the OnInboxChanged should be called at least once so that observers know that the inbox is up to date.

## Implementation

Trigger OnInboxChanged since no updates are downloaded from server.
