### PR TITLE
fix bundle structure to not create executable

### DIFF
--- a/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
+++ b/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
@@ -767,13 +767,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		075AAEE926847FE1007CA1BD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6A714B9C26F8B317004A34A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1496,8 +1489,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 075AAEEF26847FE1007CA1BD /* Build configuration list for PBXNativeTarget "Leanplum-Bundle" */;
 			buildPhases = (
-				075AAEE826847FE1007CA1BD /* Sources */,
-				075AAEE926847FE1007CA1BD /* Frameworks */,
 				075AAEEA26847FE1007CA1BD /* Resources */,
 			);
 			buildRules = (
@@ -1695,13 +1686,6 @@
 				075AAED126847EC4007CA1BD /* LPEnumConstants.m in Sources */,
 				075AAEDA26847EC4007CA1BD /* LPExceptionHandler.m in Sources */,
 				075AAE8526847EC4007CA1BD /* LPJSON.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		075AAEE826847FE1007CA1BD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LeanplumSDK/LeanplumSDKBundle/Supporting Files/Info.plist
+++ b/LeanplumSDK/LeanplumSDKBundle/Supporting Files/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-660](https://leanplum.atlassian.net/browse/SDK-660)
People Involved   | @dejan2k 

## Background
Our Leanplum bundle has executable inside and is making problems in the clients app, it's not passing AppStore validation.
## Implementation
This executable is actually not needed, because it does not contain anything, so the solution is to remove `CFBundleExecutable` key from bundle's Info.plist and to remove `Compile Sources` and `Link Binary with Libraries` from bundle's Build Phases.
## Testing steps
testing with SPM to see if the AppStore validation will pass.
## Is this change backwards-compatible?
Yes