### PR TITLE
add support in WKWebView for urls with target="_blank"

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LPWebInterstitialViewController : UIViewController <WKNavigationDelegate>
+@interface LPWebInterstitialViewController : UIViewController <WKNavigationDelegate, WKUIDelegate>
 
 @property (strong, nonatomic) LPActionContext *context;
 

--- a/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
@@ -39,6 +39,7 @@
 
     self.webView = [[WKWebView alloc] init];
     self.webView.navigationDelegate = self;
+    self.webView.UIDelegate = self;
 
     // must be inserted at index 0
     [self.view insertSubview:self.webView atIndex:0];
@@ -395,6 +396,18 @@
     NSCharacterSet *letterSet = [NSCharacterSet letterCharacterSet];
     NSArray *components = [htmlString componentsSeparatedByCharactersInSet:letterSet];
     return [[components componentsJoinedByString:@""] floatValue];
+}
+
+#pragma mark WKUIDelegate
+
+//this fix is added to support pages with target="_blank" urls
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+  if (!navigationAction.targetFrame.isMainFrame) {
+    [webView loadRequest:navigationAction.request];
+  }
+
+  return nil;
 }
 
 #pragma mark Orientation

--- a/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/MessageTemplates/ViewControllers/LPWebInterstitialViewController.m
@@ -403,11 +403,10 @@
 //this fix is added to support pages with target="_blank" urls
 - (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
 {
-  if (!navigationAction.targetFrame.isMainFrame) {
-    [webView loadRequest:navigationAction.request];
-  }
-
-  return nil;
+    if (!navigationAction.targetFrame.isMainFrame) {
+        [webView loadRequest:navigationAction.request];
+    }
+    return nil;
 }
 
 #pragma mark Orientation


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-640](https://leanplum.atlassian.net/browse/SDK-640)
People Involved   | @dejan2k 

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
By default WKWebView does not support `target="_blank"` so urls with this target were not handled
## Implementation
solution  is to cancel the navigation and load the request with loadRequest: again. This will have the similar behaviour like UIWebView which always open new window in the current frame.
[reference link](https://stackoverflow.com/a/25853806)
## Testing steps
Manual testing by sending WebInterstitial with page that has `target="_blank"` url
## Is this change backwards-compatible?
Yes