### PR TITLE
Use  requestWhenInUseAuthorization instead of requestAlwaysAuthorization

### DIFF
--- a/LeanplumSDKLocation/LeanplumSDKLocation/Classes/LPLocationManager.m
+++ b/LeanplumSDKLocation/LeanplumSDKLocation/Classes/LPLocationManager.m
@@ -196,8 +196,8 @@
 - (void)authorize {
     LP_TRY
     CLLocationManager *locationManager = [self locationManager];
-    if ([locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
-        [locationManager requestAlwaysAuthorization];
+    if ([locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+        [locationManager requestWhenInUseAuthorization];
     }
     LP_END_TRY
 }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-641](https://leanplum.atlassian.net/browse/SDK-641)
People Involved   | @dejan2k 

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
When using our Location SDK by default we had set to `requestAlwaysAuthorization` which was leading to ask for information in Info.plist meaning to add `NSLocationAlwaysAndWhenInUseUsageDescription` and for the users that were only using `NSLocationWhenInUseUsageDescription` this is not acceptable.
## Implementation
Lower the level of authorization to when in use by asking for `requestWhenInUseAuthorization` which means that only by adding `NSLocationWhenInUseUsageDescription` in Info.plist app will display the needed alert for authorizing locations and will not throw any warning
## Testing steps
Manual testing
## Is this change backwards-compatible?
Yes