### PR TITLE
Do not update variables if values are null

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Features/Variables/LPVarCache.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Features/Variables/LPVarCache.m
@@ -415,23 +415,24 @@ static dispatch_once_t leanplum_onceToken;
 {
     @synchronized (self.vars) {
         if (diffs_ || (!self.silent && !self.hasReceivedDiffs)) {
-            self.diffs = diffs_;
-            
-            if (!self.diffs) {
-                self.merged = [ContentMerger mergeWithVars:self.valuesFromClient diff:self.diffs];
-            } else {
+            // Prevent overriding variables if API returns null
+            // If no variables are defined, API returns {}
+            if (!(diffs_ == nil || [diffs_ isEqual:[NSNull null]])) {
+                self.diffs = diffs_;
                 // Merger helper will mutate diffs.
                 // We need to lock it in case multiple threads will be accessing this.
                 @synchronized (self.diffs) {
                     self.merged = [ContentMerger mergeWithVars:self.valuesFromClient diff:self.diffs];
                 }
-            }
-
-            // Update variables with new values.
-            // Have to extract the keys because a dictionary variable may add a new sub-variable,
-            // modifying the variable dictionary.
-            for (NSString *name in [self.vars allKeys]) {
-                [self.vars[name] update];
+                
+                // Update variables with new values.
+                // Have to extract the keys because a dictionary variable may add a new sub-variable,
+                // modifying the variable dictionary.
+                for (NSString *name in [self.vars allKeys]) {
+                    [self.vars[name] update];
+                }
+            } else {
+                LPLog(LPError, @"No variable values were received from the server. Please contact us to investigate.");
             }
         }
         


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [JIRA_TICKET_ID](https://leanplum.atlassian.net/browse/JIRA_TICKET_ID)
People Involved   | @nzagorchev 

## Background
A null value (or missing key value) is not permitted and should not be returned by the API for the Variables. If no variables are defined, an empty collection is returned {}.
Code won't allow variables to be replaced/updated in case of server failure.

## Implementation

## Testing steps

## Is this change backwards-compatible?
