### PR TITLE
Remove module name from xcframework swiftinterface

### DIFF
--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -203,6 +203,12 @@ build_ios_static() {
   -framework $archivePath-iphonesimulator.xcarchive/Products/Library/Frameworks/$productName.framework \
   -framework $archivePath-iphoneos.xcarchive/Products/Library/Frameworks/$productName.framework \
   -output Release/static/$productName.xcframework
+  
+  # Remove module name from xcframework swiftinterface
+  # It prevents error X is not a member of type Leanplum.Leanplum
+  # This happens when a class name is same as the module name
+  # https://stackoverflow.com/a/62310245
+  find Release/static/Leanplum.xcframework -name "*.swiftinterface" -exec sed -i -e "s/Leanplum\.//g" {} \;
 
   echo "Removing arm64 from simulator slice ..."
   lipo -remove arm64 \

--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -113,7 +113,7 @@ build_ios_dylib() {
   -scheme $scheme \
   -archivePath $archivePath-iphonesimulator.xcarchive \
   -sdk iphonesimulator \
-  -destination generic/platform=iOS \
+  -destination 'generic/platform=iOS Simulator' \
   SKIP_INSTALL=NO
 
   echo "Building $scheme dynamic (device) target ..."
@@ -186,7 +186,7 @@ build_ios_static() {
   -scheme $scheme \
   -archivePath $archivePath-iphonesimulator.xcarchive \
   -sdk iphonesimulator \
-  -destination generic/platform=iOS \
+  -destination 'generic/platform=iOS Simulator' \
   SKIP_INSTALL=NO
 
   echo "Building $scheme static (device) target ..."


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
Issue        | #495 
People Involved   | @nzagorchev 

Remove module name from xcframework swiftinterface.
The same is already done for dynamic xcframework.

Update the simulator destination to more specific one.

## Background

## Implementation

## Testing steps

## Is this change backwards-compatible?
