### PR TITLE
Use explicit dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ if: |
   ((commit_message != 'update spm') AND (sender != env(GITHUB_NAME)))
 
 language: objective-c
-osx_image: xcode13.1
+osx_image: xcode13.4
 
 xcode_workspace: Leanplum.xcworkspace
 xcode_scheme: LeanplumSDKApp

--- a/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
+++ b/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		6A07FDA52811AF3800995BE3 /* ContentMergerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDA42811AF3800995BE3 /* ContentMergerTest.swift */; };
 		6A07FDAE283544CE00995BE3 /* ActionManagerDownloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDAD283544CE00995BE3 /* ActionManagerDownloadTest.swift */; };
 		6A07FDB0283544E300995BE3 /* DictionaryValueKeyPathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDAF283544E300995BE3 /* DictionaryValueKeyPathTest.swift */; };
+		6A29EAA828E89D950024880E /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543E728E89C1E0025F2A9 /* LeanplumLocationAndBeacons.framework */; };
 		6A2FE16027958D6000E4A8FE /* GeofencingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2FE15F27958D6000E4A8FE /* GeofencingTest.m */; };
 		6A39C48F27283EE8000D5320 /* NotificationsProxyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A39C48E27283EE8000D5320 /* NotificationsProxyTest.swift */; };
 		6A54E9CD273B156600DE0E61 /* NotificationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A54E9CC273B156600DE0E61 /* NotificationsManagerTest.swift */; };
@@ -132,10 +133,6 @@
 		6A9D0A9A273430A700466133 /* NotificationTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D0A99273430A700466133 /* NotificationTestHelper.swift */; };
 		6A9DECA527B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
 		6A9DECA627B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
-		6AEAEE5A2795B68700680F84 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEAEE592795B68700680F84 /* Leanplum.framework */; };
-		6AEAEE5B2795B68700680F84 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEAEE592795B68700680F84 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6AEAEE622795B72A00680F84 /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */; };
-		6AEAEE632795B73B00680F84 /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */; };
 		779F1FAA8AA2F3872AC876B2 /* Pods_LeanplumSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3C9DA445D159EC6FF97D42D /* Pods_LeanplumSDKTests.framework */; };
 		C9D064B1275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */; };
 		C9D503672754C9DC0034C5B3 /* PushNotificationSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D503662754C9DC0034C5B3 /* PushNotificationSettingsTest.swift */; };
@@ -149,6 +146,41 @@
 			remoteGlobalIDString = 075AACE626847BF3007CA1BD;
 			remoteInfo = LeanplumSDKApp;
 		};
+		6A29EAA628E89D280024880E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 6A2FE16627958F0400E4A8FE;
+			remoteInfo = LeanplumLocationAndBeacons;
+		};
+		6AF543E428E89C1E0025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6A2FE146279578F800E4A8FE;
+			remoteInfo = LeanplumLocation;
+		};
+		6AF543E628E89C1E0025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6A2FE17427958F0400E4A8FE;
+			remoteInfo = LeanplumLocationAndBeacons;
+		};
+		6AF543E828E89C1E0025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6AEAEE712795D89D00680F84;
+			remoteInfo = "LeanplumLocation-Static";
+		};
+		6AF543EA28E89C1E0025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6AEAEE7F2795D8E700680F84;
+			remoteInfo = "LeanplumLocationAndBeacons-Static";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -158,7 +190,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6AEAEE5B2795B68700680F84 /* Leanplum.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -271,6 +302,7 @@
 		6A9DECA427B69D8800052807 /* change_host_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = change_host_response.json; sourceTree = "<group>"; };
 		6AEAEE592795B68700680F84 /* Leanplum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Leanplum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LeanplumLocationAndBeacons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDKLocation.xcodeproj; path = ../LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj; sourceTree = "<group>"; };
 		B6B7D6D71F9664181C09E727 /* Pods-LeanplumSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKTests.release.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKTests/Pods-LeanplumSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeanplumNotificationsManagerUtilsTest.swift; sourceTree = "<group>"; };
 		C9D503662754C9DC0034C5B3 /* PushNotificationSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSettingsTest.swift; sourceTree = "<group>"; };
@@ -282,8 +314,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6AEAEE622795B72A00680F84 /* LeanplumLocationAndBeacons.framework in Frameworks */,
-				6AEAEE5A2795B68700680F84 /* Leanplum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,8 +321,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A29EAA828E89D950024880E /* LeanplumLocationAndBeacons.framework in Frameworks */,
 				779F1FAA8AA2F3872AC876B2 /* Pods_LeanplumSDKTests.framework in Frameworks */,
-				6AEAEE632795B73B00680F84 /* LeanplumLocationAndBeacons.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,6 +332,7 @@
 		075AACDE26847BF3007CA1BD = {
 			isa = PBXGroup;
 			children = (
+				6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */,
 				075AACE926847BF3007CA1BD /* LeanplumSDKApp */,
 				075AAFBD26849AC1007CA1BD /* LeanplumSDKTests */,
 				075AACE826847BF3007CA1BD /* Products */,
@@ -557,6 +588,17 @@
 			path = LocationAndBeacons;
 			sourceTree = "<group>";
 		};
+		6AF543DE28E89C1E0025F2A9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6AF543E528E89C1E0025F2A9 /* LeanplumLocation.framework */,
+				6AF543E728E89C1E0025F2A9 /* LeanplumLocationAndBeacons.framework */,
+				6AF543E928E89C1E0025F2A9 /* LeanplumLocation.framework */,
+				6AF543EB28E89C1E0025F2A9 /* LeanplumLocationAndBeacons.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		E0CB0FD8F4E44175F7CB3EEF /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -601,6 +643,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6A29EAA728E89D280024880E /* PBXTargetDependency */,
 				075AAFC226849AC1007CA1BD /* PBXTargetDependency */,
 			);
 			name = LeanplumSDKTests;
@@ -639,6 +682,12 @@
 			mainGroup = 075AACDE26847BF3007CA1BD;
 			productRefGroup = 075AACE826847BF3007CA1BD /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 6AF543DE28E89C1E0025F2A9 /* Products */;
+					ProjectRef = 6AF543DD28E89C1E0025F2A9 /* LeanplumSDKLocation.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				075AACE626847BF3007CA1BD /* LeanplumSDKApp */,
@@ -646,6 +695,37 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		6AF543E528E89C1E0025F2A9 /* LeanplumLocation.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LeanplumLocation.framework;
+			remoteRef = 6AF543E428E89C1E0025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		6AF543E728E89C1E0025F2A9 /* LeanplumLocationAndBeacons.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LeanplumLocationAndBeacons.framework;
+			remoteRef = 6AF543E628E89C1E0025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		6AF543E928E89C1E0025F2A9 /* LeanplumLocation.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LeanplumLocation.framework;
+			remoteRef = 6AF543E828E89C1E0025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		6AF543EB28E89C1E0025F2A9 /* LeanplumLocationAndBeacons.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LeanplumLocationAndBeacons.framework;
+			remoteRef = 6AF543EA28E89C1E0025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		075AACE526847BF3007CA1BD /* Resources */ = {
@@ -855,6 +935,11 @@
 			isa = PBXTargetDependency;
 			target = 075AACE626847BF3007CA1BD /* LeanplumSDKApp */;
 			targetProxy = 075AAFC126849AC1007CA1BD /* PBXContainerItemProxy */;
+		};
+		6A29EAA728E89D280024880E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LeanplumLocationAndBeacons;
+			targetProxy = 6A29EAA628E89D280024880E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/LeanplumSDKApp/LeanplumSDKApp/Supporting Files/Info.plist
+++ b/LeanplumSDKApp/LeanplumSDKApp/Supporting Files/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Uses location for testing purposes</string>
+	<key>LeanplumLocationDisableAutoAuthorize</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/LPWebInterstitialViewControllerTest.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/LPWebInterstitialViewControllerTest.m
@@ -32,26 +32,6 @@
     [super tearDown];
 }
 
-/*
- * Use this for Xcode13 instead of [LPWebInterstitialViewController instantiateFromStoryboard]
- * Xcode13 cannot find the bundle using the current logic in LPUtils:leanplumBundle
- * NSBundle for Leanplum class returns the xctest from the app bundle:
- * ../LeanplumSDKApp.app/PlugIns/LeanplumSDKTests.xctest
- */
-- (LPWebInterstitialViewController*)webInterstitialController
-{
-    NSBundle *bundle = [NSBundle mainBundle];
-    NSURL *bundleUrl = [bundle URLForResource:@"Leanplum-iOS-SDK" withExtension:@".bundle" subdirectory:@"Frameworks/Leanplum.framework"];
-    if (bundleUrl != nil)
-    {
-        NSBundle *lpBundle = [NSBundle bundleWithURL:bundleUrl];
-        bundle = lpBundle;
-    }
-    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"WebInterstitial" bundle:bundle];
-    
-    return [storyboard instantiateInitialViewController];
-}
-
 // Blocks for decidePolicyForNavigationAction
 typedef void (^AfterBlock)(UIApplication *mockApplication, WKNavigationActionPolicy policy);
 typedef void (^BeforeBlock)(UIApplication *mockApplication);
@@ -65,7 +45,8 @@ typedef void (^BeforeBlock)(UIApplication *mockApplication);
  */
 - (void) execute_decidePolicyForNavigationAction:(NSURL *)url withInitialPolicy:(WKNavigationActionPolicy)initialPolicy withBeforeBlock:(BeforeBlock)beforeBlock withAfterBlock:(AfterBlock)afterBlock
 {
-    LPWebInterstitialViewController *viewController = [self webInterstitialController];
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"WebInterstitial" bundle:[LPUtils leanplumBundle]];
+    LPWebInterstitialViewController *viewController = [storyboard instantiateInitialViewController];
     
     WKWebView *currentWebView;
     for (id view in viewController.view.subviews) {

--- a/LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj/project.pbxproj
+++ b/LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj/project.pbxproj
@@ -9,10 +9,8 @@
 /* Begin PBXBuildFile section */
 		6A2FE1522795796A00E4A8FE /* LPLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2FE1502795796A00E4A8FE /* LPLocationManager.m */; };
 		6A2FE1532795796A00E4A8FE /* LPLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6A2FE1562795799100E4A8FE /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1552795799100E4A8FE /* Leanplum.framework */; };
 		6A2FE16827958F0400E4A8FE /* LPLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A2FE16A27958F0400E4A8FE /* LPLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2FE1502795796A00E4A8FE /* LPLocationManager.m */; };
-		6A2FE16D27958F0400E4A8FE /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1552795799100E4A8FE /* Leanplum.framework */; };
 		6A2FE1792795921700E4A8FE /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1782795921700E4A8FE /* CoreLocation.framework */; };
 		6A2FE17B2795952100E4A8FE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE17A2795952100E4A8FE /* Foundation.framework */; };
 		6A2FE17C2795952B00E4A8FE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE17A2795952100E4A8FE /* Foundation.framework */; };
@@ -20,16 +18,70 @@
 		6AEAEE662795D89D00680F84 /* LPLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AEAEE682795D89D00680F84 /* LPLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2FE1502795796A00E4A8FE /* LPLocationManager.m */; };
 		6AEAEE6A2795D89D00680F84 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1782795921700E4A8FE /* CoreLocation.framework */; };
-		6AEAEE6B2795D89D00680F84 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1552795799100E4A8FE /* Leanplum.framework */; };
 		6AEAEE6C2795D89D00680F84 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE17A2795952100E4A8FE /* Foundation.framework */; };
 		6AEAEE742795D8E700680F84 /* LPLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AEAEE762795D8E700680F84 /* LPLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2FE1502795796A00E4A8FE /* LPLocationManager.m */; };
 		6AEAEE782795D8E700680F84 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1782795921700E4A8FE /* CoreLocation.framework */; };
 		6AEAEE792795D8E700680F84 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE17A2795952100E4A8FE /* Foundation.framework */; };
-		6AEAEE7A2795D8E700680F84 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2FE1552795799100E4A8FE /* Leanplum.framework */; };
 		6AEAEE812795DA0100680F84 /* LPLocationManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; };
 		6AEAEE832795DA2E00680F84 /* LPLocationManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; };
+		6AF543C928E899DD0025F2A9 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; };
+		6AF543CA28E899DD0025F2A9 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6AF543D628E89BA80025F2A9 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; };
+		6AF543D728E89BA80025F2A9 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6AF543BA28E897090025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 075AAD0826847C23007CA1BD;
+			remoteInfo = Leanplum;
+		};
+		6AF543BC28E897090025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 075AAEEC26847FE1007CA1BD;
+			remoteInfo = "Leanplum-Bundle";
+		};
+		6AF543BE28E897090025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6A714BA326F8B317004A34A9;
+			remoteInfo = "Leanplum-Static";
+		};
+		6AF543C728E899380025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
+			remoteInfo = Leanplum;
+		};
+		6AF543D428E89BA10025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
+			remoteInfo = Leanplum;
+		};
+		6AF543D928E89BCB0025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 6A714AEF26F8B317004A34A9;
+			remoteInfo = "Leanplum-Static";
+		};
+		6AF543DB28E89BD20025F2A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 6A714AEF26F8B317004A34A9;
+			remoteInfo = "Leanplum-Static";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		6AEAEE802795D96500680F84 /* Copy Headers */ = {
@@ -54,6 +106,28 @@
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6AF543CB28E899DD0025F2A9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6AF543CA28E899DD0025F2A9 /* Leanplum.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6AF543D828E89BA90025F2A9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6AF543D728E89BA80025F2A9 /* Leanplum.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +140,7 @@
 		6A2FE17A2795952100E4A8FE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6AEAEE712795D89D00680F84 /* LeanplumLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LeanplumLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AEAEE7F2795D8E700680F84 /* LeanplumLocationAndBeacons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LeanplumLocationAndBeacons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDK.xcodeproj; path = ../LeanplumSDK/LeanplumSDK.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,7 +149,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A2FE17D2795953200E4A8FE /* CoreLocation.framework in Frameworks */,
-				6A2FE1562795799100E4A8FE /* Leanplum.framework in Frameworks */,
+				6AF543D628E89BA80025F2A9 /* Leanplum.framework in Frameworks */,
 				6A2FE17C2795952B00E4A8FE /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -84,8 +159,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A2FE1792795921700E4A8FE /* CoreLocation.framework in Frameworks */,
+				6AF543C928E899DD0025F2A9 /* Leanplum.framework in Frameworks */,
 				6A2FE17B2795952100E4A8FE /* Foundation.framework in Frameworks */,
-				6A2FE16D27958F0400E4A8FE /* Leanplum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,7 +169,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AEAEE6A2795D89D00680F84 /* CoreLocation.framework in Frameworks */,
-				6AEAEE6B2795D89D00680F84 /* Leanplum.framework in Frameworks */,
 				6AEAEE6C2795D89D00680F84 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -105,7 +179,6 @@
 			files = (
 				6AEAEE782795D8E700680F84 /* CoreLocation.framework in Frameworks */,
 				6AEAEE792795D8E700680F84 /* Foundation.framework in Frameworks */,
-				6AEAEE7A2795D8E700680F84 /* Leanplum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +188,7 @@
 		6A2FE13C279578F800E4A8FE = {
 			isa = PBXGroup;
 			children = (
+				6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */,
 				6A2FE148279578F800E4A8FE /* LeanplumSDKLocation */,
 				6A2FE147279578F800E4A8FE /* Products */,
 				6A2FE1542795799100E4A8FE /* Frameworks */,
@@ -157,6 +231,16 @@
 				6A2FE1502795796A00E4A8FE /* LPLocationManager.m */,
 			);
 			path = Classes;
+			sourceTree = "<group>";
+		};
+		6AF543B528E897090025F2A9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6AF543BB28E897090025F2A9 /* Leanplum.framework */,
+				6AF543BD28E897090025F2A9 /* Leanplum-iOS-SDK.bundle */,
+				6AF543BF28E897090025F2A9 /* Leanplum.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -205,10 +289,12 @@
 				6A2FE142279578F800E4A8FE /* Sources */,
 				6A2FE143279578F800E4A8FE /* Frameworks */,
 				6A2FE144279578F800E4A8FE /* Resources */,
+				6AF543D828E89BA90025F2A9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				6AF543D528E89BA10025F2A9 /* PBXTargetDependency */,
 			);
 			name = LeanplumLocation;
 			productName = LeanplumSDKLocation;
@@ -223,10 +309,12 @@
 				6A2FE16927958F0400E4A8FE /* Sources */,
 				6A2FE16C27958F0400E4A8FE /* Frameworks */,
 				6A2FE16E27958F0400E4A8FE /* Resources */,
+				6AF543CB28E899DD0025F2A9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				6AF543C828E899380025F2A9 /* PBXTargetDependency */,
 			);
 			name = LeanplumLocationAndBeacons;
 			productName = LeanplumSDKLocation;
@@ -246,6 +334,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6AF543DA28E89BCB0025F2A9 /* PBXTargetDependency */,
 			);
 			name = "LeanplumLocation-Static";
 			productName = LeanplumSDKLocation;
@@ -265,6 +354,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6AF543DC28E89BD20025F2A9 /* PBXTargetDependency */,
 			);
 			name = "LeanplumLocationAndBeacons-Static";
 			productName = LeanplumSDKLocation;
@@ -300,6 +390,12 @@
 			mainGroup = 6A2FE13C279578F800E4A8FE;
 			productRefGroup = 6A2FE147279578F800E4A8FE /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 6AF543B528E897090025F2A9 /* Products */;
+					ProjectRef = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				6A2FE145279578F800E4A8FE /* LeanplumLocation */,
@@ -309,6 +405,30 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		6AF543BB28E897090025F2A9 /* Leanplum.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Leanplum.framework;
+			remoteRef = 6AF543BA28E897090025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		6AF543BD28E897090025F2A9 /* Leanplum-iOS-SDK.bundle */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "Leanplum-iOS-SDK.bundle";
+			remoteRef = 6AF543BC28E897090025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		6AF543BF28E897090025F2A9 /* Leanplum.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Leanplum.framework;
+			remoteRef = 6AF543BE28E897090025F2A9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		6A2FE144279578F800E4A8FE /* Resources */ = {
@@ -375,6 +495,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6AF543C828E899380025F2A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Leanplum;
+			targetProxy = 6AF543C728E899380025F2A9 /* PBXContainerItemProxy */;
+		};
+		6AF543D528E89BA10025F2A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Leanplum;
+			targetProxy = 6AF543D428E89BA10025F2A9 /* PBXContainerItemProxy */;
+		};
+		6AF543DA28E89BCB0025F2A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Leanplum-Static";
+			targetProxy = 6AF543D928E89BCB0025F2A9 /* PBXContainerItemProxy */;
+		};
+		6AF543DC28E89BD20025F2A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Leanplum-Static";
+			targetProxy = 6AF543DB28E89BD20025F2A9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		6A2FE14B279578F800E4A8FE /* Debug */ = {

--- a/LeanplumSDKLocation/LeanplumSDKLocation/Classes/LPLocationManager.m
+++ b/LeanplumSDKLocation/LeanplumSDKLocation/Classes/LPLocationManager.m
@@ -29,6 +29,7 @@
 #import <Leanplum/LeanplumInternal.h>
 #import <Leanplum/LPVarCache.h>
 
+#define LP_LOCATION_DISABLE_AUTO_AUTHORIZE_KEY @"LeanplumLocationDisableAutoAuthorize"
 #define LP_REGION_IDENTIFIER_PREFIX @"__leanplum"
 #define LP_REGION_DISTANCE_NEAR 1
 #define LP_REGION_DISTANCE_IMMEDIATE 2
@@ -81,6 +82,11 @@
     LP_TRY
     if (self = [super init]) {
         _authorizeAutomatically = YES;
+        NSNumber *disableAutoAuthorize = [[NSBundle mainBundle] objectForInfoDictionaryKey:LP_LOCATION_DISABLE_AUTO_AUTHORIZE_KEY];
+        if ([disableAutoAuthorize boolValue] == YES) {
+            _authorizeAutomatically = NO;
+        }
+        
         _maxGeofences = LP_DEFAULT_MAX_GEOFENCES;
         _geofenceDistanceUpperBound = LP_DEFAULT_GEOFENCE_DISTANCE_UPPER_BOUND;
         _monitoringSignificantLocationChanges = NO;
@@ -167,12 +173,14 @@
 
     [self requestAuthorization];
 
-    // Update monitored regions.
-    _isForeground =
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // Update monitored regions.
+        self->_isForeground =
         [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
-    [self updateMaxGeofences];
-    [self setMonitoredRegions];
-    [self setApplicationStateObserversForGeofences];
+        [self updateMaxGeofences];
+        [self setMonitoredRegions];
+        [self setApplicationStateObserversForGeofences];
+    });
 }
 
 - (void)requestAuthorization


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Adding a dependency from another project where there are multiple targets that produce the same product, results in the following warning:
```
Multiple targets match implicit dependency for product reference 'Leanplum.framework'. Consider adding an explicit dependency on the intended target to resolve this ambiguity.
```

In the above case, both `Leanplum` and `Leanplum-Static` produce the same product - `Leanplum.framework`. Unfortunately, even if you choose the desired target from the list, there is no guarantee that Xcode will build that product. In this case, the dependency is implicit, hence the above warning.

The main problem is that this can result in mixing dynamic and static frameworks between targets. For example, the _dynamic_ `LeanplumLocation` to depend on the _static_ `Leanplum` instead of the _dynamic_ one. Then you end up with an unpredictable output and **multiple duplicate symbols**:
```
objc[69744]: Class MyClass is implemented in both /Users/(...)/DerivedData/MyApp/Build/Products/Debug/MyApp.app/Contents/MacOS/MyApp and /Library/Frameworks/MyFramework.framework/MyFramework. One of the two will be used. Which one is undefined.
```

The LeanplumSDKApp which holds the Unit Tests depends on `LeanplumLocationAndBeacons`, which depends on `Leanplum`. Since the underlying `Leanplum.framework` linked is static instead of dynamic, it gets embedded into the app, and the `LeanplumLocationAndBeacons.framework` is dynamically linked, and is also embedded (Embed & Sign).
Note that for both frameworks the linking is inferred so multiple combinations and problems can arise.

## Solutions
Two options are available here:
1. Rename the product, for example, `LeanplumStatic` (`LeanplumStatic.framework`) and keep the Module Name so imports and definitions stay the same. Since the products are different, we can safely 'implicitly' depend on it. 
2. Make the dependency explicit as the warning suggests, and add it in the “Target Dependencies“ Build Phase.

1) Unfortunately, this option **does not work** since renaming `Product Name` but keeping the `Product Module Name` produces a number of errors in projects using **Mixed Languages**. 
`Underlying Objective-C module 'Leanplum' not found`
`LPRequestSender+UUID.swift error build: Underlying Objective-C module 'Leanplum' not found`
This error is emitted for all Swift files that reference any code in Objective-C.
I even created a sample Framework project to test it out and the build fails if there is a Swift file in it. Works fine if it is Objective-C only.
Issue:
[No such module error after changing product module name in a framework](https://forums.swift.org/t/no-such-module-error-after-changing-product-module-name-in-a-framework/40623)
2) Explicit dependencies can be added only from the same project and not from other projects from the same workspace. This is noted in the Xcode docs:
```
Note
It’s good practice to use a workspace to manage multiple projects. However, you can’t create explicit dependencies between two projects in the same workspace.
```
[Apple Developer Documentation](https://developer.apple.com/documentation/xcode/managing-multiple-projects-and-their-dependencies) 

In order to add an explicit dependency, you need to add the same project (.xcodeproj) file inside the project that depends on it. Note that despite the nested structure now in the workspace, files are not copied, only referenced.

## Implementation
LeanplumSDK project (.xcodeproj) is also added under LeanplumSDKLocation project. This way Leanplum or Leanplum-Static can be explicitly added as dependency in the `Target Dependencies` Build Phase.

LeanplumSDKLocation project (.xcodeproj) is added under LeanplumSDKApp project, so an explicit dependency to LeanplumLocationAndBeacons can be added to the LeanplumSDKTests (Unit Tests).

## Testing steps

## Is this change backwards-compatible?
