### PR TITLE
Migration: fix AppLaunched and transform array values

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper+Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper+Utilities.swift
@@ -17,12 +17,14 @@ extension CTWrapper {
         return false
     }
     
-    var transformAttributeValues: ((Any) -> Any) {
+    var transformArrayValues: ((Any) -> Any) {
         return { value in
-            if let arr = value as? Array<Any> {
-                let arrString = arr.map {
-                    String(describing: $0)
-                }
+            if let arr = value as? Array<Any?> {
+                let arrString = arr
+                    .compactMap{ $0 }
+                    .map {
+                        String(describing: $0!)
+                    }
                 return ("[\(arrString.joined(separator: ","))]") as Any
             }
             return value

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -63,6 +63,8 @@ class CTWrapper: Wrapper {
         cleverTapInstance = CleverTap.instance(with: config, andCleverTapID: identityManager.cleverTapID)
         cleverTapInstance?.setLibrary("Leanplum")
         
+        cleverTapInstance?.notifyApplicationLaunched(withOptions: [:])
+        
         Log.debug("[Wrapper] CleverTap instance created with accountId: \(accountId)")
         
         if !identityManager.isAnonymous {
@@ -96,7 +98,7 @@ class CTWrapper: Wrapper {
             return
         }
     
-        var eventParams = params.mapValues(transformAttributeValues)
+        var eventParams = params.mapValues(transformArrayValues)
         eventParams[Constants.ValueParamName] = value
         
         if let info = info {
@@ -122,7 +124,7 @@ class CTWrapper: Wrapper {
             return
         }
     
-        var details = params.mapValues(transformAttributeValues)
+        var details = params.mapValues(transformArrayValues)
         details[Constants.ChargedEventParam] = eventName
         details[Constants.ValueParamName] = value
         
@@ -145,7 +147,7 @@ class CTWrapper: Wrapper {
         
         // item and quantity are already in the parameters
         // and they are the only ones
-        var details = params.mapValues(transformAttributeValues)
+        var details = params.mapValues(transformArrayValues)
         details[Constants.ChargedEventParam] = eventName
         details[Constants.ValueParamName] = value
         
@@ -171,7 +173,7 @@ class CTWrapper: Wrapper {
         // .compactMapValues { $0 } will not work on not optional type Any which can still hold nil
         let profileAttributes = attributes
             .filter { !isAnyNil($0.value) }
-            .mapValues(transformAttributeValues)
+            .mapValues(transformArrayValues)
             .mapKeys(transformAttributeKeys)
         
         Log.debug("[Wrapper] Leanplum.setUserAttributes will call profilePush with \(profileAttributes)")

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
@@ -69,7 +69,7 @@ class WrapperTest: XCTestCase {
                           "empty": nil] as [AnyHashable : Any]
         
         
-        let actual = attributes.mapValues(wrapper.transformAttributeValues)
+        let actual = attributes.mapValues(wrapper.transformArrayValues)
             .mapKeys(wrapper.transformAttributeKeys)
         
         let expected = ["ctName": "ct value",
@@ -80,8 +80,40 @@ class WrapperTest: XCTestCase {
                         "ctName2": "ct value 2",
                         "empty": nil] as [AnyHashable : Any]
         
-        print(actual)
-        print(expected)
         XCTAssertTrue(actual.isEqual(expected))
+    }
+    
+    func testAttributeValuesNil() {
+        let attributes = ["arr": ["a", 1, "b", 2.0, true, nil]] as [AnyHashable : Any]
+        
+        let actual = attributes.mapValues(wrapper.transformArrayValues)
+            .mapKeys(wrapper.transformAttributeKeys)
+        
+        let expected = ["arr": "[a,1,b,2.0,true]"] as [AnyHashable : Any]
+        XCTAssertTrue(actual.isEqual(expected))
+    }
+    
+    func testAttributeValuesNotNil() {
+        let attributes = ["arr": ["a", 1, "b", 2.0, true]] as [AnyHashable : Any]
+        
+        let actual = attributes.mapValues(wrapper.transformArrayValues)
+            .mapKeys(wrapper.transformAttributeKeys)
+        
+        let expected = ["arr": "[a,1,b,2.0,true]"] as [AnyHashable : Any]
+        XCTAssertTrue(actual.isEqual(expected))
+    }
+    
+    func testAttributeValuesNSNull() {
+        let attributes = ["arr": ["a", 1.99, "b", 2, true, false, 0, NSNull()]] as [AnyHashable : Any]
+        let attributesWithNil = ["arr": ["a", 1.99, "b", 2, nil, true, false, 0, NSNull(), nil]] as [AnyHashable : Any]
+        
+        let actual = attributes.mapValues(wrapper.transformArrayValues)
+            .mapKeys(wrapper.transformAttributeKeys)
+        let actualWithNil = attributesWithNil.mapValues(wrapper.transformArrayValues)
+            .mapKeys(wrapper.transformAttributeKeys)
+        
+        let expected = ["arr": "[a,1.99,b,2,true,false,0,<null>]"] as [AnyHashable : Any]
+        XCTAssertTrue(actual.isEqual(expected))
+        XCTAssertTrue(actualWithNil.isEqual(expected))
     }
 }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
1) CleverTap needs to track AppLaunched in order to track other events when initialized mid-session. This addresses the following error:
`App Launched not yet processed re-queueing`
2) Fix transforming array values if such contains `nil`. Remove the `nil` values and ensure the other elements are unwrapped.

## Implementation
1) Add `cleverTapInstance?.notifyApplicationLaunched(withOptions: [:])` once the instance is created
2) Cast the array to `Any?`, remove nil values, then create a String by force-unwrapping them.
3) Rename `transformAttributeValues` to `transformArrayValues`

## Testing steps
Manual + new Test cases

## Is this change backwards-compatible?
