### PR TITLE
Use pushInstallReferrerSource

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Managers/Networking/LPRequestSender.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Managers/Networking/LPRequestSender.m
@@ -345,9 +345,6 @@
 
             // Invoke errors on all requests.
             [LPEventCallbackManager invokeErrorCallbacksWithError:err];
-          //  [[LPOperationQueue serialQueue] cancelAllOperations];
-            
-
             
             dispatch_semaphore_signal(semaphore);
             LP_END_TRY
@@ -366,7 +363,6 @@
             NSError *error = [NSError errorWithDomain:@"Leanplum" code:1
                                              userInfo:@{NSLocalizedDescriptionKey: @"Request timed out"}];
             [LPEventCallbackManager invokeErrorCallbacksWithError:error];
-//            [[LPOperationQueue serialQueue] cancelAllOperations];
             LP_END_TRY
         }
         LP_END_TRY

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -13,7 +13,6 @@ class CTWrapper: Wrapper {
     // MARK: Constants
     enum Constants {
         static let StatePrefix = "state_"
-        static let UTMVisitedEvent = "UTM Visited"
         
         static let ValueParamName = "value"
         static let InfoParamName = "info"
@@ -206,27 +205,15 @@ class CTWrapper: Wrapper {
     
     // MARK: Traffic Source
     func setTrafficSourceInfo(_ info: [AnyHashable: Any]) {
-        let trafficSourceInfoMappings = [
-            "publisherId": "utm_source_id",
-            "publisherName": "utm_source",
-            "publisherSubPublisher": "utm_medium",
-            "publisherSubSite": "utm_subscribe.site",
-            "publisherSubCampaign": "utm_campaign",
-            "publisherSubAdGroup": "utm_sourcepublisher.ad_group",
-            "publisherSubAd": "utm_SourcePublisher.ad"
-        ]
+        let source = info["publisherName"] as? String
+        let medium = info["publisherSubPublisher"] as? String
+        let campaign = info["publisherSubCampaign"] as? String
         
-        let props = info.mapKeys({ key -> AnyHashable in
-            guard let keyStr = key as? String,
-            let newKey = trafficSourceInfoMappings[keyStr]
-            else {
-                return key
-            }
-            return newKey
-        })
-        
-        Log.debug("[Wrapper] Leanplum.setTrafficSourceInfo will call pushEvent with \(Constants.UTMVisitedEvent) and \(props)")
-        cleverTapInstance?.recordEvent(Constants.UTMVisitedEvent, withProps: props)
+        Log.debug("""
+                [Wrapper] Leanplum.setTrafficSourceInfo will call pushInstallReferrerSource \
+                with \(source ?? "null"), \(medium ?? "null") and \(campaign ?? "null")
+                """)
+        cleverTapInstance?.pushInstallReferrerSource(source, medium: medium, campaign: campaign)
     }
     
     // MARK: Log Level

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Extensions/Leanplum+Extensions.h
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Extensions/Leanplum+Extensions.h
@@ -71,7 +71,6 @@ NS_ASSUME_NONNULL_END
 + (void)maybeSendLog:(nonnull NSString *)message;
 @end
 
-
 @interface ApiConfig(UnitTest)
 @property (strong, nonatomic, nonnull) NSString *appId;
 @property (strong, nonatomic, nonnull) NSString *accessKey;

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
@@ -25,8 +25,8 @@ class WrapperTest: XCTestCase {
         let `nil` = nilString as Any
         
         XCTAssertFalse(wrapper.isAnyNil(notNil))
-        XCTAssertFalse(wrapper.isAnyNil(notNilOptional))
-        XCTAssertTrue(wrapper.isAnyNil(nilString))
+        XCTAssertFalse(wrapper.isAnyNil(notNilOptional as Any))
+        XCTAssertTrue(wrapper.isAnyNil(nilString as Any))
         XCTAssertTrue(wrapper.isAnyNil(`nil`))
     }
     
@@ -60,13 +60,15 @@ class WrapperTest: XCTestCase {
     }
     
     func testAttributeValues() {
-        let attributes = ["lpName": "ct value",
+        let values = ["lpName": "ct value",
                           "number": 4,
                           "arr": ["a", 1, "b", 2],
                           "arrStr": ["a", "b"],
                           "arrNumber": [0.5, 1.2, 2.5],
                           "lpName2": "ct value 2",
-                          "empty": nil] as [AnyHashable : Any]
+                      "empty": nil] as [String : Any?]
+        
+        let attributes = values as [AnyHashable : Any]
         
         
         let actual = attributes.mapValues(wrapper.transformArrayValues)
@@ -78,9 +80,9 @@ class WrapperTest: XCTestCase {
                         "arrStr": "[a,b]",
                         "arrNumber": "[0.5,1.2,2.5]",
                         "ctName2": "ct value 2",
-                        "empty": nil] as [AnyHashable : Any]
+                        "empty": nil] as [String : Any?]
         
-        XCTAssertTrue(actual.isEqual(expected))
+        XCTAssertTrue(actual.isEqual(expected as [AnyHashable : Any]))
     }
     
     func testAttributeValuesNil() {

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/Migration+Extensions.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/Migration+Extensions.swift
@@ -14,3 +14,9 @@ import Foundation
         migrationState = state
     }
 }
+
+@objcMembers public class MigrationManagerUtil: NSObject {
+    static func setSharedMigrateState(_ state: MigrationState) {
+        MigrationManager.shared.migrationState = state
+    }
+}

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Utilities/LeanplumHelper.m
@@ -96,13 +96,22 @@ static BOOL swizzled = NO;
     [Leanplum setLogLevel:LPLogLevelDebug];
     [Leanplum setAppId:APPLICATION_ID withDevelopmentKey:DEVELOPMENT_KEY];
     
-    [[MigrationManager shared] setMigrationState:MigrationStateLeanplum];
+    if (@available(iOS 13.0, *)) {
+        [[MigrationManager shared] setMigrationState:MigrationStateLeanplum];
+    } else {
+        [MigrationManagerUtil setSharedMigrateState:MigrationStateLeanplum];
+    }
 }
 
 + (void)setup_production_test {
+    [Leanplum setLogLevel:LPLogLevelDebug];
     [Leanplum setAppId:APPLICATION_ID withProductionKey:PRODUCTION_KEY];
     
-    [[MigrationManager shared] setMigrationState:MigrationStateLeanplum];
+    if (@available(iOS 13.0, *)) {
+        [[MigrationManager shared] setMigrationState:MigrationStateLeanplum];
+    } else {
+        [MigrationManagerUtil setSharedMigrateState:MigrationStateLeanplum];
+    }
 }
 
 + (BOOL)start_development_test {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

Use `pushInstallReferrerSource` to set traffic source info.

## Background

## Implementation
- Use `pushInstallReferrerSource` instead of tracking event.
- Fix test warnings.
- Remove commented-out code in the sender.

## Testing steps

## Is this change backwards-compatible?
