### PR TITLE
CT Push Migration

### DIFF
--- a/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
+++ b/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		6A07FDA32811911000995BE3 /* ActionManager+FileDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDA12811911000995BE3 /* ActionManager+FileDownload.swift */; };
 		6A07FDAA28352DCE00995BE3 /* ContentMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDA928352DCE00995BE3 /* ContentMerger.swift */; };
 		6A07FDAB28352DCE00995BE3 /* ContentMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A07FDA928352DCE00995BE3 /* ContentMerger.swift */; };
+		6A15EB3D28F6A5DB00878D6C /* LPCTNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A15EB3C28F6A5DB00878D6C /* LPCTNotificationsManager.swift */; };
+		6A15EB3E28F6A5DB00878D6C /* LPCTNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A15EB3C28F6A5DB00878D6C /* LPCTNotificationsManager.swift */; };
 		6A2109E128BE88D900DBF4A9 /* CTWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2109DF28BE88D900DBF4A9 /* CTWrapper.swift */; };
 		6A2109E228BE88D900DBF4A9 /* CTWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2109DF28BE88D900DBF4A9 /* CTWrapper.swift */; };
 		6A2109E328BE88D900DBF4A9 /* MigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A2109E028BE88D900DBF4A9 /* MigrationManager.swift */; };
@@ -809,6 +811,7 @@
 		6A07FD9E280F27C700995BE3 /* NSRegularExpression+Matches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Matches.swift"; sourceTree = "<group>"; };
 		6A07FDA12811911000995BE3 /* ActionManager+FileDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActionManager+FileDownload.swift"; sourceTree = "<group>"; };
 		6A07FDA928352DCE00995BE3 /* ContentMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMerger.swift; sourceTree = "<group>"; };
+		6A15EB3C28F6A5DB00878D6C /* LPCTNotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LPCTNotificationsManager.swift; sourceTree = "<group>"; };
 		6A2109DF28BE88D900DBF4A9 /* CTWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CTWrapper.swift; sourceTree = "<group>"; };
 		6A2109E028BE88D900DBF4A9 /* MigrationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationManager.swift; sourceTree = "<group>"; };
 		6A265E2527187EBB0074354F /* NotificationsProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsProxy.swift; sourceTree = "<group>"; };
@@ -1354,6 +1357,7 @@
 				6A29EABA28EA12D30024880E /* MigrationManager+Constants.swift */,
 				6A29EAC328EB56AD0024880E /* MigrationManager+ResponseHandler.swift */,
 				6A37A89828EF738200F4339F /* MigrationManager+API.swift */,
+				6A15EB3C28F6A5DB00878D6C /* LPCTNotificationsManager.swift */,
 			);
 			path = Migration;
 			sourceTree = "<group>";
@@ -1967,6 +1971,7 @@
 				39C081A32781D40200C1DBD6 /* ActionManager+Definition.swift in Sources */,
 				075AAE9826847EC4007CA1BD /* Leanplum_SocketIO.m in Sources */,
 				075AAED126847EC4007CA1BD /* LPEnumConstants.m in Sources */,
+				6A15EB3D28F6A5DB00878D6C /* LPCTNotificationsManager.swift in Sources */,
 				075AAEDA26847EC4007CA1BD /* LPExceptionHandler.m in Sources */,
 				075AAE8526847EC4007CA1BD /* LPJSON.m in Sources */,
 			);
@@ -2095,6 +2100,7 @@
 				39C081AB278D995300C1DBD6 /* ActionManager+Scheduler.swift in Sources */,
 				6A714B9826F8B317004A34A9 /* Leanplum_SocketIO.m in Sources */,
 				6A714B9926F8B317004A34A9 /* LPEnumConstants.m in Sources */,
+				6A15EB3E28F6A5DB00878D6C /* LPCTNotificationsManager.swift in Sources */,
 				6A714B9A26F8B317004A34A9 /* LPExceptionHandler.m in Sources */,
 				6A714B9B26F8B317004A34A9 /* LPJSON.m in Sources */,
 			);

--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -119,12 +119,12 @@ void leanplumExceptionHandler(NSException *exception);
 #endif
 }
 
-+ (NotificationsManager*)notificationsManager
++ (LPCTNotificationsManager*)notificationsManager
 {
-    static NotificationsManager *managerInstance = nil;
+    static LPCTNotificationsManager *managerInstance = nil;
     static dispatch_once_t onceLPInternalStateToken;
     dispatch_once(&onceLPInternalStateToken, ^{
-        managerInstance = [NotificationsManager new];
+        managerInstance = [LPCTNotificationsManager new];
     });
     return managerInstance;
 }
@@ -514,6 +514,7 @@ void leanplumExceptionHandler(NSException *exception);
 
 + (void)triggerStartIssued
 {
+    LPLog(LPDebug, @"Triggering blocks on start issued");
     [LPInternalState sharedState].issuedStart = YES;
     NSMutableArray* startIssuedBlocks = [LPInternalState sharedState].startIssuedBlocks;
 
@@ -933,7 +934,7 @@ void leanplumExceptionHandler(NSException *exception);
             [[LPRequestSender sharedInstance] send:request];
             [Leanplum triggerStartIssued];
         } else {
-            [[LPInternalState sharedState] setCalledStart:YES];
+            [[LPInternalState sharedState] setHasStarted:YES];
             [[LPInternalState sharedState] setStartSuccessful:YES];
             [Leanplum triggerStartIssued];
             [Leanplum triggerStartResponse:YES];

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
@@ -1,0 +1,69 @@
+//
+//  LPCTNotificationsManager.swift
+//  LeanplumSDK
+//
+//  Created by Nikola Zagorchev on 12.10.22.
+//
+
+import Foundation
+// Use @_implementationOnly to *not* expose CleverTapSDK to the Leanplum-Swift header
+@_implementationOnly import CleverTapSDK
+
+@objc public class LPCTNotificationsManager: NotificationsManager {
+    struct Constants {
+        static let OpenDeepLinksInForeground = true
+    }
+    
+    enum NotificationEvent: String, CustomStringConvertible {
+        case opened = "Open"
+        case received = "Receive"
+        
+        var description: String {
+            rawValue
+        }
+    }
+    
+    override func notificationOpened(userInfo: [AnyHashable : Any], action: String = LP_VALUE_DEFAULT_PUSH_ACTION) {
+        if Utilities.messageIdFromUserInfo(userInfo) != nil {
+            // Handle Leanplum notifications
+            super.notificationOpened(userInfo: userInfo, action: action)
+            return
+        }
+        handlerCleverTapNotification(userInfo: userInfo, event: .opened)
+    }
+    
+    override func notificationReceived(userInfo: [AnyHashable : Any], isForeground: Bool) {
+        if Utilities.messageIdFromUserInfo(userInfo) != nil {
+            // Handle Leanplum notifications
+            super.notificationReceived(userInfo: userInfo, isForeground: isForeground)
+            return
+        }
+        handlerCleverTapNotification(userInfo: userInfo, event: .received)
+    }
+    
+    public override func didRegisterForRemoteNotificationsWithDeviceToken(_ deviceToken: Data) {
+        super.didRegisterForRemoteNotificationsWithDeviceToken(deviceToken)
+        
+        Log.debug("[Wrapper] Will call CleverTap.setPushToken for didRegisterForRemoteNotifications, when Leanplum has issued start.")
+        // Leanplum.onStartIssued guarantees that Wrapper is initialized and CT instance is available, if migration has started.
+        Leanplum.onStartIssued {
+            if MigrationManager.shared.useCleverTap {
+                MigrationManager.shared.setPushToken(deviceToken)
+            }
+        }
+    }
+    
+    func handlerCleverTapNotification(userInfo: [AnyHashable : Any], event: NotificationEvent) {
+        Log.debug("[Wrapper] Will call CleverTap.handlePushNotification for Push \(event), when Leanplum has issued start.")
+        // Leanplum.onStartIssued guarantees that Wrapper is initialized and CT instance is available, if migration has started.
+        Leanplum.onStartIssued {
+            if MigrationManager.shared.useCleverTap {
+                Log.debug("""
+                        [Wrapper] Calling CleverTap.handlePushNotification:openDeepLinksInForeground: \
+                        \(Constants.OpenDeepLinksInForeground) for Push \(event)
+                        """)
+                CleverTap.handlePushNotification(userInfo, openDeepLinksInForeground: Constants.OpenDeepLinksInForeground)
+            }
+        }
+    }
+}

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
@@ -8,7 +8,11 @@
 @objc public extension MigrationManager {
 
     func launch() {
-        wrapper?.launch()
+        guard let wrapper = wrapper else {
+            Log.debug("[Wrapper] Calling launch before wrapper is initialized.")
+            return
+        }
+        wrapper.launch()
     }
     
     var state: MigrationState {
@@ -49,6 +53,10 @@
 
     func setUserId(_ userId: String) {
         wrapper?.setUserId(userId)
+    }
+    
+    func setPushToken(_ token: Data) {
+        wrapper?.setPushToken(token)
     }
     
     func setTrafficSourceInfo(_ info: [AnyHashable: Any]) {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
@@ -60,7 +60,7 @@ import Foundation
     }
     
     func initWrapper() {
-        if migrationState.useCleverTap {
+        if migrationState.useCleverTap, wrapper == nil {
             guard let id = accountId, let token = accountToken, let accountRegion = regionCode else {
                 Log.error("[Wrapper] Missing CleverTap Credentials. Cannot initialize CleverTap.")
                 return

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/Wrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/Wrapper.swift
@@ -31,6 +31,8 @@ protocol Wrapper {
     
     func setUserId(_ userId: String)
     
+    func setPushToken(_ token: Data)
+    
     func setTrafficSourceInfo(_ info: [AnyHashable: Any])
     
     func setLogLevel(_ level: LeanplumLogLevel)

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Notifications/NSObject+Notifications.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Notifications/NSObject+Notifications.swift
@@ -74,11 +74,6 @@ extension NSObject {
             }
         }
         
-        // Do not handle non-Leanplum notifications
-        guard Utilities.messageIdFromUserInfo(userInfo) != nil else {
-            return
-        }
-        
         let state = UIApplication.shared.applicationState
         // Call notification received or perform action
         if #available(iOS 10, *) {
@@ -154,11 +149,6 @@ extension NSObject {
             }
         }
         
-        // Do not handle non-Leanplum notifications
-        guard Utilities.messageIdFromUserInfo(userInfo) != nil else {
-            return
-        }
-        
         // Handle UNNotificationDefaultActionIdentifier and Custom Actions
         if response.actionIdentifier != UNNotificationDismissActionIdentifier {
             let notifWasOpenedFromStart = notificationsProxy.isEqualToHandledNotification(userInfo: userInfo) && notificationsProxy.notificationOpenedFromStart
@@ -190,11 +180,6 @@ extension NSObject {
             }
         }
         
-        // Do not handle non-Leanplum notifications
-        guard Utilities.messageIdFromUserInfo(notification.request.content.userInfo) != nil else {
-            return
-        }
-        
         // Notification is received while app is running on foreground
         Leanplum.notificationsManager().notificationReceived(userInfo: notification.request.content.userInfo, isForeground: true)
     }
@@ -211,8 +196,7 @@ extension NSObject {
             }
         }
         
-        // Do not handle non-Leanplum notifications
-        guard let userInfo = notification.userInfo, Utilities.messageIdFromUserInfo(userInfo) != nil else {
+        guard let userInfo = notification.userInfo else {
             return
         }
         


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2316](https://wizrocket.atlassian.net/browse/SDK-2316)
People Involved   | @nzagorchev 

## Background
Support Notifications from both Leanplum and CleverTap

CT swizzling is not called (no swizzling of iOS delegate methods) when using a custom instance and the method is internal.
Instead of using double swizzling, check if the notification comes from Leanplum and if not, forward it to CleverTap to handle it using the `CleverTap.handlePushNotification` method.

## Implementation
Create a new `NotificationsManager` that inherits from it and handles both CT and LP notifications. Override the push `receive` and `open` methods. Call the corresponding SDK based on the push payload. Handle registration with a device token as well.

For CT, ensure that `CleverTap.handlePushNotification` and `CleverTap.setPushToken` methods are called _once we have an instance initialized_.
Set the push token when the CT instance is initialized, based on the token cached by Leanplum, using `instance.setPushTokenAs`.

The Leanplum Notifications Object is also modified to _not_ filter out the notifications. This logic is moved to the `NotificationsManager`.

Note that CT does not send the "content-available" flag, so the app will _not_ be woken up by a CT notification.

### Example payloads
Leanplum
```
{
   "_lpn":5187874616049123,
   "aps":{
      "alert =""Push message goes here.",
      "content-available"= 1,
      "mutable-content"= 1
   },
   "_lpx":{
      "__name__""="""
   },
   "LP_URL":"https":,
   "apns-push-type":"alert"
}
```
CleverTap
```
{
   "W$rnv":0,
   "wzrk_dl":"https":,
   "W$pivot":"wzrk_default",
   "ct_mediaType":"image",
   "wzrk_acct_id":W84-WW7-123A,
   "ct_mediaUrl":"https"://db7hsdc8829us.cloudfront.net/...,
   "W$dt":"APPLE",
   "W$id":0_0,
   "aps":{
      "alert ="{
         "body = message",
         "title = hello"
      };
    badge = 3,
      "mutable-content"= 1
   }
}
```

## Testing steps
Testing Push is received and opened when:
- the app is not running
- the app is not running, and the app is woken up by push (Background Mode: Remote notification)
- the app is running in background
- the app is on foreground

## Is this change backwards-compatible?
Yes