### PR TITLE
Fix resume called on app start

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -1103,7 +1103,9 @@ void leanplumExceptionHandler(NSException *exception);
                     //if they are changed the new valeus will be updated to server as well
                     [[Leanplum notificationsManager] updateNotificationSettings];
         
-                    [Leanplum resume];
+                    if ([Leanplum hasStarted]) {
+                        [Leanplum resume];
+                    }
         
                     // Used for push notifications iOS 9
                     [Leanplum notificationsManager].proxy.resumedTimeInterval = [[NSDate date] timeIntervalSince1970];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
`UIApplicationWillEnterForegroundNotification` is called when app is started and enters foreground.

## Implementation
Add a check if Leanplum has started, to prevent calling resume right after start.

## Testing steps

## Is this change backwards-compatible?
