### PR TITLE
Validate and Hash CTID

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -21,6 +21,8 @@ class CTWrapper: Wrapper {
         static let iOSTransactionIdentifierParam = "iOSTransactionIdentifier"
         static let iOSReceiptDataParam = "iOSReceiptData"
         static let iOSSandboxParam = "iOSSandbox"
+        
+        static let DevicesUserProperty = "devices"
     }
     
     // MARK: Initialization
@@ -67,6 +69,8 @@ class CTWrapper: Wrapper {
                     """)
             cleverTapInstance?.onUserLogin(identityManager.profile,
                                            withCleverTapID: identityManager.cleverTapID)
+            
+            setDevicesProperty()
         }
         triggerInstanceCallback()
     }
@@ -196,6 +200,8 @@ class CTWrapper: Wrapper {
                 and CleverTapID:  \(cleverTapID)")
                 """)
         cleverTapInstance?.onUserLogin(profile, withCleverTapID: cleverTapID)
+        
+        setDevicesProperty()
     }
     
     func setPushToken(_ token: Data) {
@@ -207,6 +213,15 @@ class CTWrapper: Wrapper {
         if let token = Leanplum.user.pushToken {
             Log.debug("[Wrapper] Setting current push token using setPushTokenAs")
             cleverTapInstance?.setPushTokenAs(token)
+        }
+    }
+    
+    func setDevicesProperty() {
+        if !identityManager.isValidCleverTapID {
+            if let devices = cleverTapInstance?.profileGet(Constants.DevicesUserProperty) as? [String],
+               devices.contains(identityManager.deviceId) {
+                cleverTapInstance?.profileAddMultiValue(identityManager.deviceId, forKey: Constants.DevicesUserProperty)
+            }
         }
     }
     

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -217,12 +217,8 @@ class CTWrapper: Wrapper {
     }
     
     func setDevicesProperty() {
-        if !identityManager.isValidCleverTapID {
-            if let devices = cleverTapInstance?.profileGet(Constants.DevicesUserProperty) as? [String],
-               devices.contains(identityManager.deviceId) {
-                cleverTapInstance?.profileAddMultiValue(identityManager.deviceId, forKey: Constants.DevicesUserProperty)
-            }
-        }
+        // CleverTap SDK ensures the values are unique locally
+        cleverTapInstance?.profileAddMultiValue(identityManager.deviceId, forKey: Constants.DevicesUserProperty)
     }
     
     // MARK: Traffic Source

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
@@ -9,17 +9,18 @@ import Foundation
 // Use @_implementationOnly to *not* expose CleverTapSDK to the Leanplum-Swift header
 @_implementationOnly import CleverTapSDK
 
-// TODO: fix description
 /**
  * Identity mapping between Leanplum userId and deviceId and CleverTap Identity and CTID.
  *
  *  Mappings:
  *  - anonymous: <CTID=deviceId, Identity=null>
- *  - non-anonymous to <CTID=deviceId_userId, Identity=userId>
+ *  - non-anonymous to <CTID=deviceId_userIdHash, Identity=userId>
+ *
+ *  UserId Hash is generated using the first 10 chars of the userId SHA256 string.
  *
  *  - Note: On login of anonymous user, a merge should happen. CleverTap SDK allows merges
  *  only when the CTID remains the same, meaning that the merged profile would get the anonymous
- *  profile's CTID: <CTID=deviceId, Identity=userId>.
+ *  profile's CTID: <CTID=deviceId, Identity=userIdHash>.
  *  In order to keep track which is that userId, it is saved into `anonymousLoginUserId`.
  *  For this userId, the CTID is always set to deviceId.
  *  Leanplum UserId can be set through Leanplum.start and Leanplum.setUserId
@@ -33,7 +34,7 @@ class IdentityManager {
         static let AnonymousLoginUserIdKey = "__leanplum_anonymous_login_user_id"
         static let IdentityStateKey = "__leanplum_identity_state"
         
-        static let CTIDLengthLimit = 50
+        static let DeviceIdLengthLimit = 50
         static let IdentityHashLength = 10
     }
     
@@ -87,37 +88,46 @@ class IdentityManager {
         state = IdentityState.identified()
     }
     
-    var identity: String {
-        // TODO: handle errors
-        guard let str = Utilities.sha256(string: userId) else { return userId }
+    var userIdHash: String {
+        guard let str = Utilities.sha256(string: userId) else {
+            Log.error("[Wrapper] Failed to generate SHA256 for userId: \(userId)")
+            return userId
+        }
         
         let endIndex = str.index(str.startIndex, offsetBy: Constants.IdentityHashLength)
         return String(str[..<endIndex])
     }
+
+    var isValidCleverTapID: Bool {
+        // Only the deviceId could be invalid, since the userIdHash should always be valid,
+        // but we still validate the whole CTID to be safe
+        CleverTap.isValidCleverTapId(originalCleverTapID) &&
+        deviceId.count <= Constants.DeviceIdLengthLimit
+    }
     
+    var originalCleverTapID: String {
+        if shouldAppendUserId {
+            return "\(deviceId)_\(userIdHash)"
+        }
+        
+        return deviceId
+    }
+
     var cleverTapID: String {
         if isValidCleverTapID {
             return originalCleverTapID
         }
         
-        // TODO: handle errors
-        let sha256_128 = Utilities.sha256_128(string: deviceId)!
-        
-        return "\(sha256_128)_\(identity)"
-    }
-    
-    var isValidCleverTapID: Bool {
-        CleverTap.isValidCleverTapId(originalCleverTapID) &&
-        deviceId.count <= Constants.CTIDLengthLimit
-    }
-    
-    var originalCleverTapID: String {
-        if userId != anonymousLoginUserId,
-           userId != deviceId {
-            return "\(deviceId)_\(identity)"
+        guard let ctDevice = Utilities.sha256_128(string: deviceId) else {
+            Log.error("[Wrapper] Failed to generate SHA256 for deviceId: \(deviceId)")
+            return originalCleverTapID
         }
         
-        return deviceId
+        if shouldAppendUserId {
+            return "\(ctDevice)_\(userIdHash)"
+        }
+        
+        return ctDevice
     }
     
     var profile: [AnyHashable: Any] {
@@ -126,5 +136,9 @@ class IdentityManager {
     
     var isAnonymous: Bool {
         userId == deviceId
+    }
+    
+    var shouldAppendUserId: Bool {
+        userId != anonymousLoginUserId && userId != deviceId
     }
 }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
@@ -15,8 +15,11 @@ import Foundation
  *  Mappings:
  *  - anonymous: <CTID=deviceId, Identity=null>
  *  - non-anonymous to <CTID=deviceId_userIdHash, Identity=userId>
+ *  - if invalid deviceId <deviceId=deviceIdHash>
  *
- *  UserId Hash is generated using the first 10 chars of the userId SHA256 string.
+ *  UserId Hash is generated using the first 10 chars of the userId SHA256 string (hex).
+ *  If the deviceId does _not_ pass validation _or_ is _longer_ than 50 characters,
+ *  the first 32 chars of the deviceId SHA256 string (hex) are used as deviceIdHash.
  *
  *  - Note: On login of anonymous user, a merge should happen. CleverTap SDK allows merges
  *  only when the CTID remains the same, meaning that the merged profile would get the anonymous

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CommonCrypto
 
-public class Utilities: NSObject {    
+public class Utilities: NSObject {
     /**
      * Returns Leanplum message Id from Notification userInfo.
      * Use this method to identify Leanplum Notifications
@@ -40,8 +40,19 @@ public class Utilities: NSObject {
     @objc public static func sha256_128(string: String) -> String? {
         guard let str = sha256(string: string) else { return nil }
         
-        let length = 256/2/4
-        let endIndex = str.index(str.startIndex, offsetBy: length)
-        return String(str[..<endIndex])
+        let hexLength = 256/2/4
+        return substring(string: str, openEndIndex: hexLength)
+    }
+    
+    @objc public static func sha256_40(string: String) -> String? {
+        guard let str = sha256(string: string) else { return nil }
+        
+        let hexLength = 40/4
+        return substring(string: str, openEndIndex: hexLength)
+    }
+    
+    static func substring(string: String, openEndIndex: Int) -> String {
+        let endIndex = string.index(string.startIndex, offsetBy: openEndIndex)
+        return String(string[..<endIndex])
     }
 }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
@@ -8,7 +8,6 @@
 import Foundation
 import CommonCrypto
 
-// TODO: Remove Utilities class when we add proper models
 public class Utilities: NSObject {    
     /**
      * Returns Leanplum message Id from Notification userInfo.

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Leanplum. All rights reserved.
 
 import Foundation
+import CommonCrypto
 
 // TODO: Remove Utilities class when we add proper models
 public class Utilities: NSObject {    
@@ -21,5 +22,27 @@ public class Utilities: NSObject {
             return String(describing: messageId)
         }
         return nil
+    }
+    
+    @objc public static func sha256(data: Data) -> Data {
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+        return Data(hash)
+    }
+    
+    @objc public static func sha256(string: String) -> String? {
+        guard let messageData = string.data(using: String.Encoding.utf8) else { return nil }
+        let hashedData = sha256(data: messageData)
+        return hashedData.hexEncodedString()
+    }
+    
+    @objc public static func sha256_128(string: String) -> String? {
+        guard let str = sha256(string: string) else { return nil }
+        
+        let length = 256/2/4
+        let endIndex = str.index(str.startIndex, offsetBy: length)
+        return String(str[..<endIndex])
     }
 }

--- a/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
+++ b/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		6A39C48F27283EE8000D5320 /* NotificationsProxyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A39C48E27283EE8000D5320 /* NotificationsProxyTest.swift */; };
 		6A54E9CD273B156600DE0E61 /* NotificationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A54E9CC273B156600DE0E61 /* NotificationsManagerTest.swift */; };
 		6A81EDDE284681D8001B4BE9 /* TiedPrioritiesDelay.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A81EDDD284681D8001B4BE9 /* TiedPrioritiesDelay.json */; };
+		6A8411BB2903080A009F0431 /* UtilitiesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8411BA2903080A009F0431 /* UtilitiesTest.swift */; };
 		6A9D0A9627342BA300466133 /* NotificationsProxyiOS9Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D0A9527342BA300466133 /* NotificationsProxyiOS9Test.swift */; };
 		6A9D0A9827342EE300466133 /* NotificationsManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D0A9727342EE300466133 /* NotificationsManagerMock.swift */; };
 		6A9D0A9A273430A700466133 /* NotificationTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D0A99273430A700466133 /* NotificationTestHelper.swift */; };
@@ -335,6 +336,7 @@
 		6A39C48E27283EE8000D5320 /* NotificationsProxyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsProxyTest.swift; sourceTree = "<group>"; };
 		6A54E9CC273B156600DE0E61 /* NotificationsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManagerTest.swift; sourceTree = "<group>"; };
 		6A81EDDD284681D8001B4BE9 /* TiedPrioritiesDelay.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TiedPrioritiesDelay.json; sourceTree = "<group>"; };
+		6A8411BA2903080A009F0431 /* UtilitiesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitiesTest.swift; sourceTree = "<group>"; };
 		6A9D0A9527342BA300466133 /* NotificationsProxyiOS9Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsProxyiOS9Test.swift; sourceTree = "<group>"; };
 		6A9D0A9727342EE300466133 /* NotificationsManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsManagerMock.swift; sourceTree = "<group>"; };
 		6A9D0A99273430A700466133 /* NotificationTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestHelper.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				075AB1082684AAD9007CA1BD /* Utilities */,
 				6A39C48D27283EE7000D5320 /* LeanplumSDKTests-Bridging-Header.h */,
 				6A07FDAF283544E300995BE3 /* DictionaryValueKeyPathTest.swift */,
+				6A8411BA2903080A009F0431 /* UtilitiesTest.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1018,6 +1021,7 @@
 				C9D503672754C9DC0034C5B3 /* PushNotificationSettingsTest.swift in Sources */,
 				075AB1262684AAD9007CA1BD /* LPRequest+Extension.m in Sources */,
 				6A9D0A9A273430A700466133 /* NotificationTestHelper.swift in Sources */,
+				6A8411BB2903080A009F0431 /* UtilitiesTest.swift in Sources */,
 				075AB12B2684AAD9007CA1BD /* LPOpenUrlMessageTemplateTest.m in Sources */,
 				075AB1132684AAD9007CA1BD /* LPEventDataManagerTest.m in Sources */,
 				075AB1122684AAD9007CA1BD /* LPUtilsTest.m in Sources */,

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -17,9 +17,9 @@ class IdentityManagerTest: XCTestCase {
     let userId2 = "userId2"
     
     // 6ccb21214ffd60b0fc2c1607cf6a05be6a0fed9c74819eb6a92e1bd6717b28eb
-    let userId_sha = "6ccb21214f"
+    let userId_hash = "6ccb21214f"
     // c9430313f85740d3c62dd8bf8c8d275165e96f830e7b1e6ddf3a89ba17ee5cce
-    let userId2_sha = "c9430313f8"
+    let userId2_hash = "c9430313f8"
     
     let totalIdLengthLimit = 61
     
@@ -39,7 +39,7 @@ class IdentityManagerTest: XCTestCase {
     
     func testUserIdHashSha() {
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
-        XCTAssertEqual(identityManager.userIdHash, userId_sha)
+        XCTAssertEqual(identityManager.userIdHash, userId_hash)
     }
     
     func testUserIdHashWithSha() {
@@ -64,7 +64,7 @@ class IdentityManagerTest: XCTestCase {
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
     }
     
     func testIdentifiedNewUser() {
@@ -75,7 +75,7 @@ class IdentityManagerTest: XCTestCase {
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
         XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
     }
     
     func testAnonymousLogin() {
@@ -85,7 +85,7 @@ class IdentityManagerTest: XCTestCase {
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
         XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
@@ -98,8 +98,8 @@ class IdentityManagerTest: XCTestCase {
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_sha)")
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
     }
     
     func testAnonymousLoginBack() {
@@ -123,7 +123,7 @@ class IdentityManagerTest: XCTestCase {
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
         XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
@@ -139,7 +139,7 @@ class IdentityManagerTest: XCTestCase {
         let deviceId = Array(repeating: "1", count: 50).joined()
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_hash)")
         XCTAssertTrue(identityManager.cleverTapID.count == totalIdLengthLimit)
     }
     
@@ -159,7 +159,7 @@ class IdentityManagerTest: XCTestCase {
         
         let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
-        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
@@ -169,7 +169,7 @@ class IdentityManagerTest: XCTestCase {
         
         let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
-        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
@@ -189,7 +189,7 @@ class IdentityManagerTest: XCTestCase {
         
         let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
-        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
@@ -233,7 +233,7 @@ class IdentityManagerTest: XCTestCase {
             print("\(i) -> \(id)")
             print(hashes[i]!)
             print(identityManager.cleverTapID)
-            XCTAssertEqual(identityManager.cleverTapID, "\(hashes[i]!)_\(userId_sha)")
+            XCTAssertEqual(identityManager.cleverTapID, "\(hashes[i]!)_\(userId_hash)")
             XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
         }
     }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -11,27 +11,56 @@ import XCTest
 
 class IdentityManagerTest: XCTestCase {
     
+    let userId = "userId"
+    let deviceId = "deviceId"
+    
+    let userId2 = "userId2"
+    
+    // 6ccb21214ffd60b0fc2c1607cf6a05be6a0fed9c74819eb6a92e1bd6717b28eb
+    let userId_sha = "6ccb21214f"
+    // c9430313f85740d3c62dd8bf8c8d275165e96f830e7b1e6ddf3a89ba17ee5cce
+    let userId2_sha = "c9430313f8"
+    
+    let totalIdLengthLimit = 61
+    
     func testProfile() {
-        let identityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        let identityManagerUser = IdentityManagerMock(userId: "userId", deviceId: "deviceId")
+        let identityManagerUser = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        XCTAssertTrue(identityManager.profile.isEqual(["Identity": "deviceId"]))
-        XCTAssertTrue(identityManagerUser.profile.isEqual(["Identity": "userId"]))
+        XCTAssertTrue(identityManager.profile.isEqual(["Identity": deviceId]))
+        XCTAssertTrue(identityManagerUser.profile.isEqual(["Identity": userId]))
+    }
+    
+    func testUserIdHash() {
+        let identityManager = IdentityManagerMock(userId: "some-user-id", deviceId: deviceId)
+        XCTAssertTrue(identityManager.userIdHash.count == 10)
+    }
+    
+    func testUserIdHashSha() {
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
+        XCTAssertEqual(identityManager.userIdHash, userId_sha)
+    }
+    
+    func testUserIdHashWithSha() {
+        let userId = "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa"
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
+        let sha = Utilities.sha256(string: userId)!
+        let index = sha.index(sha.startIndex, offsetBy: 10)
+        let expected = String(sha[..<index])
+        XCTAssertEqual(identityManager.userIdHash, expected)
     }
     
     func testAnonymous() {
-        let identityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
         XCTAssertTrue(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.anonymous())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId")
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
     func testIdentified() {
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: "deviceId")
-        
-        let userId_sha = "6ccb21214f"
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
@@ -39,10 +68,9 @@ class IdentityManagerTest: XCTestCase {
     }
     
     func testIdentifiedNewUser() {
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        identityManager.setUserId("userId2")
-        let userId2_sha = "c9430313f8"
+        identityManager.setUserId(userId2)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
@@ -51,91 +79,162 @@ class IdentityManagerTest: XCTestCase {
     }
     
     func testAnonymousLogin() {
-        let identityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        identityManager.setUserId("userId")
+        identityManager.setUserId(userId)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, "userId")
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId")
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
     func testAnonymousLoginNewUser() {
-        let identityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        identityManager.setUserId("userId")
+        identityManager.setUserId(userId)
         
-        identityManager.setUserId("userId2")
-        let userId2_sha = "c9430313f8"
+        identityManager.setUserId(userId2)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, "userId")
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
         XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_sha)")
     }
     
     func testAnonymousLoginBack() {
-        let identityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        identityManager.setUserId("userId")
+        identityManager.setUserId(userId)
         
-        identityManager.setUserId("userId2")
+        identityManager.setUserId(userId2)
         
-        identityManager.setUserId("userId")
+        identityManager.setUserId(userId)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId")
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
     func testAnonymousLoginStart() {
-        let initialIdentityManager = IdentityManagerMock(userId: "deviceId", deviceId: "deviceId")
+        let initialIdentityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        let identityManager = IdentityManagerMockStatic(userId: "userId", deviceId: initialIdentityManager.deviceId, anonymousLoginUserId: initialIdentityManager.anonymousLoginUserId, state: initialIdentityManager.state)
+        let identityManager = IdentityManagerMockStatic(userId: userId, deviceId: initialIdentityManager.deviceId, anonymousLoginUserId: initialIdentityManager.anonymousLoginUserId, state: initialIdentityManager.state)
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, "userId")
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId")
+        XCTAssertEqual(identityManager.anonymousLoginUserId, userId)
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
+    }
+    
+    func testAnonymousLimitDeviceId() {
+        let deviceId = Array(repeating: "1", count: 50).joined()
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
+        
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
     func testIdentifiedLimitDeviceId() {
         let deviceId = Array(repeating: "1", count: 50).joined()
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
-        
-        let userId_sha = "6ccb21214f"
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_sha)")
+        XCTAssertTrue(identityManager.cleverTapID.count == totalIdLengthLimit)
+    }
+    
+    func testAnonymousLongDeviceId() {
+        let deviceId = Array(repeating: "1", count: 51).joined()
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
+        
+        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        
+        XCTAssertEqual(identityManager.cleverTapID, deviceId_sha)
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
     func testIdentifiedLongDeviceId() {
         let deviceId = Array(repeating: "1", count: 51).joined()
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let userId_sha = "6ccb21214f"
-        let deviceId_sha = "c383f53b5708fc0975ba1ac052c650c0"
+        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
     func testIdentifiedLongerDeviceId() {
         let deviceId = Array(repeating: "1", count: 60).joined()
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let userId_sha = "6ccb21214f"
-        let deviceId_sha = "70d36dedb311176c76ecd7f78d72340d"
+        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+    }
+    
+    func testAnonymousInvalidDeviceId() {
+        let deviceId = Array(repeating: "&", count: 10).joined()
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
+        
+        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        
+        XCTAssertEqual(identityManager.cleverTapID, deviceId_sha)
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
     func testIdentifiedInvalidDeviceId() {
         let deviceId = Array(repeating: "&", count: 10).joined()
-        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let userId_sha = "6ccb21214f"
-        let deviceId_sha = "595b6f123778a4903ea51b67b2aaac9e"
+        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+    }
+    
+    func testIdentifiedEmailUserId() {
+        let userId = "test@test.com"
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
+
+        // f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a
+        let userId_sha = "f660ab912e"
+
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_sha)")
+        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+    }
+    
+    func testInvalidUserIds() {
+        let invalidDeviceIds = [
+            // -\:\"fcea8952-0ae1-411d-b23c-50661050ded1\"
+            #"-\:\"fcea8952-0ae1-411d-b23c-50661050ded1\""#,
+            // abd6039873\",4562412546555904
+            #"abd6039873\",4562412546555904"#,
+            // !22113163828\""
+            #"!22113163828\"""#,
+            // "22121327322\",4562412546555904
+            // 117669683\""
+            #"""
+            "22121327322\",4562412546555904"
+            117669683\""
+            """#,
+            // 117669683\""
+            #"117669683\"""#,
+            "嘁脂Ήᔠ䦐ࠐ䤰†",
+            "{{device.hardware_id}}",
+            "116115935'2",
+            "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa"
+        ]
+        
+        let hashes = invalidDeviceIds.map(Utilities.sha256_128(string:))
+        
+        for (i, id) in invalidDeviceIds.enumerated() {
+            let identityManager = IdentityManagerMock(userId: userId, deviceId: id)
+            print("\(i) -> \(id)")
+            print(hashes[i]!)
+            print(identityManager.cleverTapID)
+            XCTAssertEqual(identityManager.cleverTapID, "\(hashes[i]!)_\(userId_sha)")
+            XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+        }
     }
 }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDKTests
 //
 //  Created by Nikola Zagorchev on 7.10.22.
-//
+//  Copyright © 2022 Leanplum. All rights reserved.
 
 import Foundation
 import XCTest
@@ -31,20 +31,23 @@ class IdentityManagerTest: XCTestCase {
     func testIdentified() {
         let identityManager = IdentityManagerMock(userId: "userId", deviceId: "deviceId")
         
+        let userId_sha = "6ccb21214f"
+        
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_userId")
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_sha)")
     }
     
     func testIdentifiedNewUser() {
         let identityManager = IdentityManagerMock(userId: "userId", deviceId: "deviceId")
         
         identityManager.setUserId("userId2")
+        let userId2_sha = "c9430313f8"
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
         XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_userId2")
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_sha)")
     }
     
     func testAnonymousLogin() {
@@ -64,11 +67,12 @@ class IdentityManagerTest: XCTestCase {
         identityManager.setUserId("userId")
         
         identityManager.setUserId("userId2")
+        let userId2_sha = "c9430313f8"
         
         XCTAssertFalse(identityManager.isAnonymous)
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
         XCTAssertEqual(identityManager.anonymousLoginUserId, "userId")
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_userId2")
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_sha)")
     }
     
     func testAnonymousLoginBack() {
@@ -94,5 +98,44 @@ class IdentityManagerTest: XCTestCase {
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
         XCTAssertEqual(identityManager.anonymousLoginUserId, "userId")
         XCTAssertEqual(identityManager.cleverTapID, "deviceId")
+    }
+    
+    func testIdentifiedLimitDeviceId() {
+        let deviceId = Array(repeating: "1", count: 50).joined()
+        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        
+        let userId_sha = "6ccb21214f"
+        
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_sha)")
+    }
+    
+    func testIdentifiedLongDeviceId() {
+        let deviceId = Array(repeating: "1", count: 51).joined()
+        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        
+        let userId_sha = "6ccb21214f"
+        let deviceId_sha = "c383f53b5708fc0975ba1ac052c650c0"
+        
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+    }
+    
+    func testIdentifiedLongerDeviceId() {
+        let deviceId = Array(repeating: "1", count: 60).joined()
+        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        
+        let userId_sha = "6ccb21214f"
+        let deviceId_sha = "70d36dedb311176c76ecd7f78d72340d"
+        
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
+    }
+    
+    func testIdentifiedInvalidDeviceId() {
+        let deviceId = Array(repeating: "&", count: 10).joined()
+        let identityManager = IdentityManagerMock(userId: "userId", deviceId: deviceId)
+        
+        let userId_sha = "6ccb21214f"
+        let deviceId_sha = "595b6f123778a4903ea51b67b2aaac9e"
+        
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_sha)")
     }
 }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
@@ -3,6 +3,97 @@
 //  LeanplumSDKTests
 //
 //  Created by Nikola Zagorchev on 21.10.22.
-//
+//  Copyright © 2022 Leanplum. All rights reserved.
 
 import Foundation
+import XCTest
+@testable import Leanplum
+
+class UtilitiesTest: XCTestCase {
+    func testSHA256(){
+        let strings = [
+            // -\:\"fcea8952-0ae1-411d-b23c-50661050ded1\"
+            #"-\:\"fcea8952-0ae1-411d-b23c-50661050ded1\""#,
+            // abd6039873\",4562412546555904
+            #"abd6039873\",4562412546555904"#,
+            // !22113163828\""
+            #"!22113163828\"""#,
+            // "22121327322\",4562412546555904
+            // 117669683\""
+        #"""
+        "22121327322\",4562412546555904"
+        117669683\""
+        """#,
+            // 117669683\""
+            #"117669683\"""#,
+            "嘁脂Ήᔠ䦐ࠐ䤰†",
+            "{{device.hardware_id}}",
+            "116115935'2"
+        ]
+        
+        let hashes = [
+            "9d68d70f279f830c1e313e813c4b8d672669a8f1a89e87fa268a9a6bc328b704",
+            "5b2efdf24962f9c2678f9bb7d30508f499e2be39b928be1986d1eb70190bf2b4",
+            "6ca78ed8e23d7851d1d72d90c3b69bcbbbb32dbc8d691d59690d8c444724c372",
+            "8bc024a346531a167229f3e431bbec8cba2d73a8d0b0eff6a490e960ace4ddc5",
+            "62f3106d53b24f8755c67b49404af3df416f1c889ccf8867bf8eb6fabee82748",
+            "5aafde83f3d6a6e8cb35a058976af376fd84311e07a03b03dd9c30dc7c90cc61",
+            "03b5c746e38ff7753d8f4854fdaee8cab68d451523e0c534eb00af653816fbc7",
+            "68b400b82ffcaea8f34f883c54753a88a09beac0f14518c9aa4d55f21fd103f2"
+        ]
+        
+        for (i, str) in strings.enumerated() {
+            XCTAssertEqual(Utilities.sha256(string: str)!, hashes[i])
+        }
+    }
+    
+    func testSHA256Normal(){
+        let strings = [
+            "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa",
+            "test@test.com",
+            "2ed5184d449e4bbbeef008569a79943c0b3996b1",
+            "33a4878d89f77737",
+            "CB226263-54C6-4BA9-BA10-CC6D083F9559",
+            "032bc2fd2e59449c",
+            "744E9F39-EDF1-4460-9C23-DF2827007295",
+            "E3311F58_D7BC_4154_8705_C614332E38A1"
+        ]
+        
+        let hashes = [
+            "68a971cf29b8b95159a66317a22ab8eaaadae7140b177dd91345d2809ed9b08b",
+            "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a",
+            "2849cfc7e464db9e0aafe689f3389de51cd35c44585d6d6183319194deb15c82",
+            "64780c16b0a8897d390cb31aa788bd6a8bbbe488cac93d1aff0578746cb70f4b",
+            "235fcc26fe5ce4c8f9a307c38aa99f5dbb59f838c81218051c38786ad4d5f162",
+            "2ae02aa4705cd42b311f460148491c049d1d1c9e88f04fc2d2653c5b92b2c454",
+            "239bcb0aedf9594a9aea2dc59a5e8aba3a5c23cc203890e44a61c4950dab3052",
+            "9aa07b6f47bb0e01f5e43037ac1d6fc0b0a779e141fef1db715d3ac9497206f6"
+        ]
+        
+        for (i, str) in strings.enumerated() {
+            XCTAssertEqual(Utilities.sha256(string: str)!, hashes[i])
+        }
+    }
+    
+    func testSHA256_128(){
+        let strings = [
+            "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa",
+            "test@test.com",
+            "CB226263-54C6-4BA9-BA10-CC6D083F9559",
+            "E3311F58_D7BC_4154_8705_C614332E38A1"
+        ]
+        
+        let hashes = [
+            "68a971cf29b8b95159a66317a22ab8eaaadae7140b177dd91345d2809ed9b08b",
+            "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a",
+            "235fcc26fe5ce4c8f9a307c38aa99f5dbb59f838c81218051c38786ad4d5f162",
+            "9aa07b6f47bb0e01f5e43037ac1d6fc0b0a779e141fef1db715d3ac9497206f6"
+        ]
+        
+        for (i, str) in strings.enumerated() {
+            let hash = Utilities.sha256_128(string: str)!
+            XCTAssertEqual(hash.count, 32)
+            XCTAssertTrue(hashes[i].contains(hash))
+        }
+    }
+}

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
@@ -1,0 +1,8 @@
+//
+//  UtilitiesTest.swift
+//  LeanplumSDKTests
+//
+//  Created by Nikola Zagorchev on 21.10.22.
+//
+
+import Foundation

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,6 @@ target 'LeanplumSDKTests' do
 end
 
 def clever_tap
-  ## TODO: use official version when released
   pod 'CleverTap-iOS-SDK', '~> 4.1.4'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,11 @@ target 'LeanplumSDKTests' do
     pod 'OHHTTPStubs', '~> 9.0.0'
 end
 
+def clever_tap
+  ## TODO: use official version when released
+  pod 'CleverTap-iOS-SDK', :git => 'https://github.com/CleverTap/clevertap-ios-sdk.git', :branch => 'task/SDK-2331-custom-ctid-changes'
+end
+
 target 'Leanplum' do
   project 'LeanplumSDK/LeanplumSDK.xcodeproj'
   workspace 'Leanplum.xcworkspace'
@@ -18,7 +23,7 @@ target 'Leanplum' do
   use_frameworks!
 
   # Pods for Leanplum
-  pod 'CleverTap-iOS-SDK', '~> 4.1.1'
+  clever_tap
 end
 #
 
@@ -26,7 +31,7 @@ target 'Leanplum-Static' do
   project 'LeanplumSDK/LeanplumSDK.xcodeproj'
 
   # Pods for Leanplum-Static
-  pod 'CleverTap-iOS-SDK', '~> 4.1.1'
+  clever_tap
 end
 
 post_install do |installer|

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ end
 
 def clever_tap
   ## TODO: use official version when released
-  pod 'CleverTap-iOS-SDK', :git => 'https://github.com/CleverTap/clevertap-ios-sdk.git', :branch => 'task/SDK-2331-custom-ctid-changes'
+  pod 'CleverTap-iOS-SDK', '~> 4.1.4'
 end
 
 target 'Leanplum' do


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2352](https://wizrocket.atlassian.net/browse/SDK-2352)
People Involved   | @nzagorchev 

## Background
The CTID generated until now, could contain invalid symbols or exceed the designated length.
Current format:
* anonymous `<CTID=deviceId, Identity=null>`
* non-anonymous `<CTID=deviceId_userId, Identity=userId>`

New format:
* anonymous `<CTID=deviceId, Identity=null>`
* non-anonymous `<CTID=deviceId_userIdHash, Identity=userId>`
* if invalid deviceId `deviceId=deviceIdHash`

The userId Hash is generated using the first 10 chars of the userId SHA256 string (hex).

If the deviceId does _not_ pass validation _or_ is _longer_ than 50 characters, we use the first 32 chars of the deviceId SHA256 string (hex).

## Implementation
Using CommonCrypto for SHA256.

## Testing steps
Unit tests

## Is this change backwards-compatible?
