### PR TITLE
Change device id hash length

### DIFF
--- a/Leanplum-iOS-SDK.podspec
+++ b/Leanplum-iOS-SDK.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.resource_bundle = {
       'Leanplum-iOS-SDK' => 'LeanplumSDK/LeanplumSDKBundle/Resources/**/*'
     }
-    s.dependency 'CleverTap-iOS-SDK', '~> 4.1'
+    s.dependency 'CleverTap-iOS-SDK', '~> 4.1.4'
     s.swift_version = '5.0'
   end
   

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -22,7 +22,7 @@ class CTWrapper: Wrapper {
         static let iOSReceiptDataParam = "iOSReceiptData"
         static let iOSSandboxParam = "iOSSandbox"
         
-        static let DevicesUserProperty = "devices"
+        static let DevicesUserProperty = "lp_devices"
     }
     
     // MARK: Initialization

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -23,6 +23,7 @@ class CTWrapper: Wrapper {
         static let iOSSandboxParam = "iOSSandbox"
         
         static let DevicesUserProperty = "lp_devices"
+        static let AnonymousDeviceUserProperty = "lp_device"
     }
     
     // MARK: Initialization
@@ -69,8 +70,11 @@ class CTWrapper: Wrapper {
                     """)
             cleverTapInstance?.onUserLogin(identityManager.profile,
                                            withCleverTapID: identityManager.cleverTapID)
-            
             setDevicesProperty()
+        } else {
+            if !identityManager.isValidCleverTapID {
+                cleverTapInstance?.profilePush([Constants.AnonymousDeviceUserProperty: identityManager.deviceId])
+            }
         }
         triggerInstanceCallback()
     }
@@ -218,7 +222,9 @@ class CTWrapper: Wrapper {
     
     func setDevicesProperty() {
         // CleverTap SDK ensures the values are unique locally
-        cleverTapInstance?.profileAddMultiValue(identityManager.deviceId, forKey: Constants.DevicesUserProperty)
+        if !identityManager.isValidCleverTapID {
+            cleverTapInstance?.profileAddMultiValue(identityManager.deviceId, forKey: Constants.DevicesUserProperty)
+        }
     }
     
     // MARK: Traffic Source

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
@@ -106,9 +106,8 @@ class IdentityManager {
     }
 
     var isValidCleverTapID: Bool {
-        // Only the deviceId could be invalid, since the userIdHash should always be valid,
-        // but we still validate the whole CTID to be safe
-        CleverTap.isValidCleverTapId(originalCleverTapID) &&
+        // Only the deviceId could be invalid, since the userIdHash should always be valid
+        CleverTap.isValidCleverTapId(deviceId) &&
         deviceId.count <= Constants.DeviceIdLengthLimit
     }
     

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/IdentityManager.swift
@@ -125,7 +125,7 @@ class IdentityManager {
             return originalCleverTapID
         }
         
-        guard let ctDevice = Utilities.sha256_128(string: deviceId) else {
+        guard let ctDevice = Utilities.sha256_200(string: deviceId) else {
             Log.error("[Wrapper] Failed to generate SHA256 for deviceId: \(deviceId)")
             return originalCleverTapID
         }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Utilities/Utilities.swift
@@ -37,10 +37,10 @@ public class Utilities: NSObject {
         return hashedData.hexEncodedString()
     }
     
-    @objc public static func sha256_128(string: String) -> String? {
+    @objc public static func sha256_200(string: String) -> String? {
         guard let str = sha256(string: string) else { return nil }
         
-        let hexLength = 256/2/4
+        let hexLength = 200/4
         return substring(string: str, openEndIndex: hexLength)
     }
     

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -22,6 +22,7 @@ class IdentityManagerTest: XCTestCase {
     let userId2_hash = "c9430313f8"
     
     let totalIdLengthLimit = 61
+    let deviceIdHashLength = 50
     
     func testProfile() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
@@ -128,7 +129,7 @@ class IdentityManagerTest: XCTestCase {
     }
     
     func testAnonymousLimitDeviceId() {
-        let deviceId = Array(repeating: "1", count: 50).joined()
+        let deviceId = Array(repeating: "1", count: deviceIdHashLength).joined()
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
         XCTAssertEqual(identityManager.cleverTapID, deviceId)
@@ -136,7 +137,7 @@ class IdentityManagerTest: XCTestCase {
     }
     
     func testIdentifiedLimitDeviceId() {
-        let deviceId = Array(repeating: "1", count: 50).joined()
+        let deviceId = Array(repeating: "1", count: deviceIdHashLength).joined()
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_hash)")
@@ -144,40 +145,41 @@ class IdentityManagerTest: XCTestCase {
     }
     
     func testAnonymousLongDeviceId() {
-        let deviceId = Array(repeating: "1", count: 51).joined()
+        let deviceId = Array(repeating: "1", count: deviceIdHashLength + 1).joined()
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        let deviceId_sha = Utilities.sha256_200(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, deviceId_sha)
+        XCTAssertTrue(identityManager.cleverTapID.count == deviceIdHashLength)
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
     }
     
     func testIdentifiedLongDeviceId() {
-        let deviceId = Array(repeating: "1", count: 51).joined()
+        let deviceId = Array(repeating: "1", count: deviceIdHashLength + 1).joined()
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        let deviceId_sha = Utilities.sha256_200(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
-        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+        XCTAssertTrue(identityManager.cleverTapID.count == totalIdLengthLimit)
     }
     
     func testIdentifiedLongerDeviceId() {
-        let deviceId = Array(repeating: "1", count: 60).joined()
+        let deviceId = Array(repeating: "1", count: deviceIdHashLength + 10).joined()
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        let deviceId_sha = Utilities.sha256_200(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
-        XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
+        XCTAssertTrue(identityManager.cleverTapID.count == totalIdLengthLimit)
     }
     
     func testAnonymousInvalidDeviceId() {
         let deviceId = Array(repeating: "&", count: 10).joined()
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
-        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        let deviceId_sha = Utilities.sha256_200(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, deviceId_sha)
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
@@ -187,7 +189,7 @@ class IdentityManagerTest: XCTestCase {
         let deviceId = Array(repeating: "&", count: 10).joined()
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        let deviceId_sha = Utilities.sha256_128(string: deviceId)!
+        let deviceId_sha = Utilities.sha256_200(string: deviceId)!
         
         XCTAssertEqual(identityManager.cleverTapID, "\(deviceId_sha)_\(userId_hash)")
         XCTAssertTrue(identityManager.cleverTapID.count <= totalIdLengthLimit)
@@ -226,7 +228,7 @@ class IdentityManagerTest: XCTestCase {
             "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa"
         ]
         
-        let hashes = invalidDeviceIds.map(Utilities.sha256_128(string:))
+        let hashes = invalidDeviceIds.map(Utilities.sha256_200(string:))
         
         for (i, id) in invalidDeviceIds.enumerated() {
             let identityManager = IdentityManagerMock(userId: userId, deviceId: id)

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/UtilitiesTest.swift
@@ -91,8 +91,8 @@ class UtilitiesTest: XCTestCase {
         ]
         
         for (i, str) in strings.enumerated() {
-            let hash = Utilities.sha256_128(string: str)!
-            XCTAssertEqual(hash.count, 32)
+            let hash = Utilities.sha256_200(string: str)!
+            XCTAssertEqual(hash.count, 50)
             XCTAssertTrue(hashes[i].contains(hash))
         }
     }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background

- Change deviceId hash length to 50, to minimize collisions for anonymous users.
- Rename `devices` user property to `lp_devices`
- Set `lp_device` for anonymous users, so merging multiple anonymous users does not override `lp_devices`
- Use `lp_devices` for non-anonymous users only

## Implementation

## Testing steps

## Is this change backwards-compatible?
