### PR TITLE
Prevent resume actions on app start

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -922,6 +922,8 @@ void leanplumExceptionHandler(NSException *exception);
         }
     
         if ([[MigrationManager shared] useLeanplum]) {
+            // hasStarted and startSuccessful will be set from the request callbacks
+            // triggerStartResponse will be called from the request callbacks
             [[LPRequestSender sharedInstance] send:request];
             [Leanplum triggerStartIssued];
         } else {
@@ -1089,17 +1091,18 @@ void leanplumExceptionHandler(NSException *exception);
                     //if they are changed the new valeus will be updated to server as well
                     [[Leanplum notificationsManager] updateNotificationSettings];
         
-                    if ([Leanplum hasStarted]) {
-                        [Leanplum resume];
-                    }
-        
                     // Used for push notifications iOS 9
                     [Leanplum notificationsManager].proxy.resumedTimeInterval = [[NSDate date] timeIntervalSince1970];
-                    [self maybePerformActions:@[@"resume"]
-                                withEventName:nil
-                                   withFilter:kLeanplumActionFilterAll
-                                fromMessageId:nil
-                         withContextualValues:nil];
+        
+                    if ([Leanplum hasStarted]) {
+                        [Leanplum resume];
+                        [self maybePerformActions:@[@"resume"]
+                                    withEventName:nil
+                                       withFilter:kLeanplumActionFilterAll
+                                    fromMessageId:nil
+                             withContextualValues:nil];
+                    }
+        
                     LP_END_TRY
                 }];
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA | [SDK-2386](https://wizrocket.atlassian.net/browse/SDK-2386)
People Involved   | @nzagorchev 

## Background
`UIApplicationWillEnterForegroundNotification` calls the block when the app is starting (immediately after `didFinishLaunchingWithOptions`). This results in executing `maybePerformActions` for `resume` before the application has started, showing an in-app unintended.

## Implementation
Execute `resume` logic only if Leanplum has already `started`. Resuming the application before calling Leanplum `start` will be a NOP.

## Testing steps

## Is this change backwards-compatible?
