### PR TITLE
Migration config public getters

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
@@ -10,6 +10,22 @@
         return migrationState
     }
     
+    var cleverTapAccountId: String? {
+        return accountId
+    }
+    
+    var cleverTapAccountToken: String? {
+        return accountToken
+    }
+    
+    var cleverTapAccountRegion: String? {
+        return regionCode
+    }
+    
+    var cleverTapAttributeMappings: [String: String] {
+        return attributeMappings
+    }
+    
     var hasLaunched: Bool {
         guard let wrapper = wrapper else { return false }
         


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Public read-only access to the CleverTap migration config.
This way PropertyWrappers can be kept internal as well.

## Implementation

## Testing steps

## Is this change backwards-compatible?
