### PR TITLE
Bump CleverTap SDK version

### DIFF
--- a/Leanplum-iOS-SDK.podspec
+++ b/Leanplum-iOS-SDK.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     s.resource_bundle = {
       'Leanplum-iOS-SDK' => 'LeanplumSDK/LeanplumSDKBundle/Resources/**/*'
     }
-    s.dependency 'CleverTap-iOS-SDK', '~> 4.1.5'
+    s.dependency 'CleverTap-iOS-SDK', '~> 4.2.0'
     s.swift_version = '5.0'
   end
   

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "LeanplumLocation", targets: ["LeanplumLocation"])
     ],
     dependencies: [
-        .package(url: "https://github.com/CleverTap/clevertap-ios-sdk", from: "4.1.5")
+        .package(url: "https://github.com/CleverTap/clevertap-ios-sdk", from: "4.2.0")
     ],
     targets: [
         .binaryTarget(

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ target 'LeanplumSDKTests' do
 end
 
 def clever_tap
-  pod 'CleverTap-iOS-SDK', '~> 4.1.5'
+  pod 'CleverTap-iOS-SDK', '~> 4.2.0'
 end
 
 target 'Leanplum' do


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2535](https://wizrocket.atlassian.net/browse/SDK-2535)
People Involved   | @nzagorchev 

## Background
Update CleverTap SDK to 4.2.0, so SDWebImage dependency can be updated.
Issue #549 

## Implementation

## Testing steps

## Is this change backwards-compatible?
