### PR TITLE
Do not use dynamic umbrella framework

### DIFF
--- a/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
+++ b/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -226,10 +226,6 @@
 		6A37A89D28EF748800F4339F /* Dictionary+MapKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A37A89B28EF748800F4339F /* Dictionary+MapKeys.swift */; };
 		6A37A8A028EF74E900F4339F /* CTWrapper+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A37A89F28EF74E900F4339F /* CTWrapper+Utilities.swift */; };
 		6A37A8A128EF74E900F4339F /* CTWrapper+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A37A89F28EF74E900F4339F /* CTWrapper+Utilities.swift */; };
-		6A3C1EB228D7B3C700D51E44 /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A3C1EB028D7B3C700D51E44 /* CleverTapSDK.framework */; };
-		6A3C1EB328D7B3C700D51E44 /* CleverTapSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A3C1EB028D7B3C700D51E44 /* CleverTapSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6A3C1EB428D7B3C700D51E44 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A3C1EB128D7B3C700D51E44 /* SDWebImage.framework */; };
-		6A3C1EB528D7B3C700D51E44 /* SDWebImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6A3C1EB128D7B3C700D51E44 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6A714AF326F8B317004A34A9 /* LPConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 075AADDA26847EC4007CA1BD /* LPConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A714AF426F8B317004A34A9 /* LPActionTriggerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 075AADC726847EC3007CA1BD /* LPActionTriggerManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A714AF526F8B317004A34A9 /* LPWebInterstitialViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 075AAD7426847EC3007CA1BD /* LPWebInterstitialViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -524,18 +520,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		6A3C1EB628D7B3C700D51E44 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				6A3C1EB528D7B3C700D51E44 /* SDWebImage.framework in Embed Frameworks */,
-				6A3C1EB328D7B3C700D51E44 /* CleverTapSDK.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		6A714BA526F8B4E6004A34A9 /* Copy Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -859,8 +843,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A3C1EB228D7B3C700D51E44 /* CleverTapSDK.framework in Frameworks */,
-				6A3C1EB428D7B3C700D51E44 /* SDWebImage.framework in Frameworks */,
 				EF8C42881E834252F5F5ABA6 /* Pods_Leanplum.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1634,8 +1616,6 @@
 				075AAD0426847C23007CA1BD /* Sources */,
 				075AAD0526847C23007CA1BD /* Frameworks */,
 				075AAD0626847C23007CA1BD /* Resources */,
-				6A3C1EAF28D7B30400D51E44 /* Copy Frameworks */,
-				6A3C1EB628D7B3C700D51E44 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1776,25 +1756,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		6A3C1EAF28D7B30400D51E44 /* Copy Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Frameworks";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Copy dependency Pods Frameworks to top level so they can be found and embedded.\n# This Run Script Phase needs to run before \"Embed Frameworks\" built-in one.\n# When a framework is linked both dynamically and statically, name of the linking is added to the framework folder name\nCOPY_FRAMEWORKS_TO_EMBED=(\"CleverTap-iOS-SDK-framework\" \"SDWebImage-framework\")\n\nfor FRAMEWORK in ${COPY_FRAMEWORKS_TO_EMBED[@]};\ndo\n cp -R -L \"${BUILT_PRODUCTS_DIR}/$FRAMEWORK/\" ${BUILT_PRODUCTS_DIR}/\ndone\n";
 		};
 		6F7CCB8DAE13D687016AB7D9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
+++ b/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -140,7 +140,10 @@
 		6A9DECA527B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
 		6A9DECA627B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
 		6AF543A228E883AD0025F2A9 /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF5439728E882CA0025F2A9 /* LeanplumLocationAndBeacons.framework */; };
+		6AF6426D298198160021A997 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; };
+		6AF6426E298198160021A997 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		779F1FAA8AA2F3872AC876B2 /* Pods_LeanplumSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3C9DA445D159EC6FF97D42D /* Pods_LeanplumSDKTests.framework */; };
+		82DC3FE9A5761B14AF26B301 /* Pods_LeanplumSDKApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 916957E1B3EE91A34170B5C7 /* Pods_LeanplumSDKApp.framework */; };
 		C9D064B1275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */; };
 		C9D503672754C9DC0034C5B3 /* PushNotificationSettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D503662754C9DC0034C5B3 /* PushNotificationSettingsTest.swift */; };
 /* End PBXBuildFile section */
@@ -216,6 +219,13 @@
 			remoteGlobalIDString = 6A2FE16627958F0400E4A8FE;
 			remoteInfo = LeanplumLocationAndBeacons;
 		};
+		6AF6426F298198220021A997 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AA13C742900546400EDCA69 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
+			remoteInfo = Leanplum;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -225,6 +235,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6AF6426E298198160021A997 /* Leanplum.framework in Embed Frameworks */,
 				6A37A8D228F03C8D00F4339F /* LeanplumLocationAndBeacons.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -322,7 +333,9 @@
 		07828DAC268B4A5E0029A339 /* local_caps_week_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = local_caps_week_response.json; sourceTree = "<group>"; };
 		07828DAD268B4A5E0029A339 /* local_caps_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = local_caps_response.json; sourceTree = "<group>"; };
 		07828DB6268B4AA00029A339 /* LPLocalCapsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LPLocalCapsTest.m; sourceTree = "<group>"; };
+		214C76D0E799A19388CD6FD8 /* Pods-LeanplumSDKApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKApp.debug.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKApp/Pods-LeanplumSDKApp.debug.xcconfig"; sourceTree = "<group>"; };
 		39C081A7278D95ED00C1DBD6 /* ActionManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionManagerTest.swift; sourceTree = "<group>"; };
+		413582C5894FCF059F11DC9B /* Pods-LeanplumSDKApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKApp.release.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKApp/Pods-LeanplumSDKApp.release.xcconfig"; sourceTree = "<group>"; };
 		4747227FD8352F14AF070969 /* Pods-LeanplumSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKTests/Pods-LeanplumSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6A07FDA42811AF3800995BE3 /* ContentMergerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMergerTest.swift; sourceTree = "<group>"; };
 		6A07FDAD283544CE00995BE3 /* ActionManagerDownloadTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionManagerDownloadTest.swift; sourceTree = "<group>"; };
@@ -345,6 +358,7 @@
 		6AEAEE592795B68700680F84 /* Leanplum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Leanplum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LeanplumLocationAndBeacons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AF5438D28E882CA0025F2A9 /* LeanplumSDKLocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDKLocation.xcodeproj; path = ../LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj; sourceTree = "<group>"; };
+		916957E1B3EE91A34170B5C7 /* Pods_LeanplumSDKApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeanplumSDKApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6B7D6D71F9664181C09E727 /* Pods-LeanplumSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKTests.release.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKTests/Pods-LeanplumSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeanplumNotificationsManagerUtilsTest.swift; sourceTree = "<group>"; };
 		C9D503662754C9DC0034C5B3 /* PushNotificationSettingsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSettingsTest.swift; sourceTree = "<group>"; };
@@ -356,7 +370,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6AF6426D298198160021A997 /* Leanplum.framework in Frameworks */,
 				6A37A8D128F03C8D00F4339F /* LeanplumLocationAndBeacons.framework in Frameworks */,
+				82DC3FE9A5761B14AF26B301 /* Pods_LeanplumSDKApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -421,6 +437,7 @@
 				6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */,
 				6AEAEE592795B68700680F84 /* Leanplum.framework */,
 				E3C9DA445D159EC6FF97D42D /* Pods_LeanplumSDKTests.framework */,
+				916957E1B3EE91A34170B5C7 /* Pods_LeanplumSDKApp.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -671,6 +688,8 @@
 			children = (
 				4747227FD8352F14AF070969 /* Pods-LeanplumSDKTests.debug.xcconfig */,
 				B6B7D6D71F9664181C09E727 /* Pods-LeanplumSDKTests.release.xcconfig */,
+				214C76D0E799A19388CD6FD8 /* Pods-LeanplumSDKApp.debug.xcconfig */,
+				413582C5894FCF059F11DC9B /* Pods-LeanplumSDKApp.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -683,15 +702,17 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 075AACFB26847BF4007CA1BD /* Build configuration list for PBXNativeTarget "LeanplumSDKApp" */;
 			buildPhases = (
+				8A261CE7954C4FB8940D097A /* [CP] Check Pods Manifest.lock */,
 				075AACE326847BF3007CA1BD /* Sources */,
 				075AACE426847BF3007CA1BD /* Frameworks */,
 				075AACE526847BF3007CA1BD /* Resources */,
 				6A37A8CD28F03C2A00F4339F /* Embed Frameworks */,
-				6A37A8D028F03C5A00F4339F /* Codesign Embedded Frameworks */,
+				E68D5EF82B25DDDEEF3430A4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				6AF64270298198220021A997 /* PBXTargetDependency */,
 				6A37A8D428F03C9400F4339F /* PBXTargetDependency */,
 			);
 			name = LeanplumSDKApp;
@@ -920,24 +941,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6A37A8D028F03C5A00F4339F /* Codesign Embedded Frameworks */ = {
+		8A261CE7954C4FB8940D097A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Codesign Embedded Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LeanplumSDKApp-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Populate a variable with the current code signing identity if it's available in the environment.\nSIGNING_IDENTITY=\"${EXPANDED_CODE_SIGN_IDENTITY:-$CODE_SIGN_IDENTITY}\"\n\n# Populate a variable with the current code signing flags and options in the environment.\nOTHER_CODE_SIGN_FLAGS=${OTHER_CODE_SIGN_FLAGS:-}\nTARGET_FRAMEWORKS_PATH=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\"\n# Re-sign the packaged frameworks using the application's details.\nif [ -n \"${SIGNING_IDENTITY}\" ]; then\n    if [[ -d $TARGET_FRAMEWORKS_PATH ]]\n    then\n        find \"$TARGET_FRAMEWORKS_PATH\" \\\n        -name \"*.framework\" \\\n        -type d \\\n        -exec codesign ${OTHER_CODE_SIGN_FLAGS} \\\n            --force \\\n            --sign \"${SIGNING_IDENTITY}\" \\\n            --options runtime \\\n            --deep \\\n            {} \\;\n    fi\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		CCAE818569231C43601E87E0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -976,6 +1000,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E68D5EF82B25DDDEEF3430A4 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-LeanplumSDKApp/Pods-LeanplumSDKApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-LeanplumSDKApp/Pods-LeanplumSDKApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LeanplumSDKApp/Pods-LeanplumSDKApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1063,6 +1104,11 @@
 			isa = PBXTargetDependency;
 			name = LeanplumLocationAndBeacons;
 			targetProxy = 6AF543A028E8834E0025F2A9 /* PBXContainerItemProxy */;
+		};
+		6AF64270298198220021A997 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Leanplum;
+			targetProxy = 6AF6426F298198220021A997 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1204,6 +1250,7 @@
 		};
 		075AACFC26847BF4007CA1BD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 214C76D0E799A19388CD6FD8 /* Pods-LeanplumSDKApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1228,6 +1275,7 @@
 		};
 		075AACFD26847BF4007CA1BD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 413582C5894FCF059F11DC9B /* Pods-LeanplumSDKApp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj/project.pbxproj
+++ b/LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj/project.pbxproj
@@ -26,9 +26,7 @@
 		6AEAEE812795DA0100680F84 /* LPLocationManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; };
 		6AEAEE832795DA2E00680F84 /* LPLocationManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 6A2FE1512795796A00E4A8FE /* LPLocationManager.h */; };
 		6AF543C928E899DD0025F2A9 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; };
-		6AF543CA28E899DD0025F2A9 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6AF543D628E89BA80025F2A9 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; };
-		6AF543D728E89BA80025F2A9 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6AF6426A298197D00021A997 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF543BB28E897090025F2A9 /* Leanplum.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,13 +58,6 @@
 			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
 			remoteInfo = Leanplum;
 		};
-		6AF543D428E89BA10025F2A9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
-			remoteInfo = Leanplum;
-		};
 		6AF543D928E89BCB0025F2A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
@@ -80,6 +71,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6A714AEF26F8B317004A34A9;
 			remoteInfo = "Leanplum-Static";
+		};
+		6AF64268298197B40021A997 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6AF543B428E897090025F2A9 /* LeanplumSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 075AAD0726847C23007CA1BD;
+			remoteInfo = Leanplum;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -106,28 +104,6 @@
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6AF543CB28E899DD0025F2A9 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				6AF543CA28E899DD0025F2A9 /* Leanplum.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6AF543D828E89BA90025F2A9 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				6AF543D728E89BA80025F2A9 /* Leanplum.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -149,7 +125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A2FE17D2795953200E4A8FE /* CoreLocation.framework in Frameworks */,
-				6AF543D628E89BA80025F2A9 /* Leanplum.framework in Frameworks */,
+				6AF6426A298197D00021A997 /* Leanplum.framework in Frameworks */,
 				6A2FE17C2795952B00E4A8FE /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -289,12 +265,11 @@
 				6A2FE142279578F800E4A8FE /* Sources */,
 				6A2FE143279578F800E4A8FE /* Frameworks */,
 				6A2FE144279578F800E4A8FE /* Resources */,
-				6AF543D828E89BA90025F2A9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				6AF543D528E89BA10025F2A9 /* PBXTargetDependency */,
+				6AF64269298197B40021A997 /* PBXTargetDependency */,
 			);
 			name = LeanplumLocation;
 			productName = LeanplumSDKLocation;
@@ -309,7 +284,6 @@
 				6A2FE16927958F0400E4A8FE /* Sources */,
 				6A2FE16C27958F0400E4A8FE /* Frameworks */,
 				6A2FE16E27958F0400E4A8FE /* Resources */,
-				6AF543CB28E899DD0025F2A9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -502,11 +476,6 @@
 			name = Leanplum;
 			targetProxy = 6AF543C728E899380025F2A9 /* PBXContainerItemProxy */;
 		};
-		6AF543D528E89BA10025F2A9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Leanplum;
-			targetProxy = 6AF543D428E89BA10025F2A9 /* PBXContainerItemProxy */;
-		};
 		6AF543DA28E89BCB0025F2A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Leanplum-Static";
@@ -516,6 +485,11 @@
 			isa = PBXTargetDependency;
 			name = "Leanplum-Static";
 			targetProxy = 6AF543DB28E89BD20025F2A9 /* PBXContainerItemProxy */;
+		};
+		6AF64269298197B40021A997 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Leanplum;
+			targetProxy = 6AF64268298197B40021A997 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Podfile
+++ b/Podfile
@@ -3,16 +3,23 @@ use_modular_headers!
 
 workspace 'Leanplum.xcworkspace'
 
+def clever_tap
+  pod 'CleverTap-iOS-SDK', '~> 4.2.0'
+end
+
+target 'LeanplumSDKApp' do
+    project 'LeanplumSDKApp/LeanplumSDKApp.xcodeproj'
+    use_frameworks!
+
+    clever_tap
+end
+
 target 'LeanplumSDKTests' do
     project 'LeanplumSDKApp/LeanplumSDKApp.xcodeproj'
     use_frameworks!
 
     pod 'OCMock', '~> 3.3.1'
     pod 'OHHTTPStubs', '~> 9.0.0'
-end
-
-def clever_tap
-  pod 'CleverTap-iOS-SDK', '~> 4.2.0'
 end
 
 target 'Leanplum' do


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2616](https://wizrocket.atlassian.net/browse/SDK-2616)
People Involved   | @nzagorchev 

## Background
Leanplum dynamic framework was an umbrella framework and embedded its dependency - CleverTapSDK and its dependencies, in the nested Frameworks folder. This was previously discouraged by Apple but now causes the AppStore Validation to fail with the following errors:
`"Invalid Bundle. The bundle at 'MyApp.app/Frameworks/Leanplum.framework' contains disallowed file 'Frameworks'".`
`"Invalid Bundle. The bundle at 'MyApp.app/Frameworks/Leanplum.framework' contains disallowed nested bundles".`

## Implementation
- LeanplumSDK - Do not embed the dependency frameworks. Remove the script that copied them.
- LeanplumLocation - Do not embed Leanplum framework.
- LeanplumSDKApp - Embed Leanplum.framework together with LeanplumLocationAndBeacons which depends on it. Install dependencies using CocoaPods. Remove the build phase script for signing since its no longer needed.

Update the build script, so it also adds the dependencies (CleverTapSDK and SDWebImage) into the Leanplum.framework zip. 

When using the dynamic Leanplum framework, developers need to add and embed all dependencies as well.

## Testing steps
Manual - AppStore validation.

## Is this change backwards-compatible?
Yes