### PR TITLE
Implement migration identity keys

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 6.10.22.
-//  Copyright © 2022 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 @objc public extension MigrationManager {
     var state: MigrationState {
@@ -24,6 +24,10 @@
     
     var cleverTapAttributeMappings: [String: String] {
         return attributeMappings
+    }
+    
+    var cleverTapIdentityKeys: [String] {
+        return identityKeys
     }
     
     var hasLaunched: Bool {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+Constants.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+Constants.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 2.10.22.
-//  Copyright © 2022 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 
@@ -15,15 +15,9 @@ import Foundation
         static let MigrationStateKey = "__leanplum_migration_state"
         static let RegionCodeKey = "__leanplum_region_code"
         static let AttributeMappingsKey = "__leanplum_attribute_mappings"
+        static let IdentityKeysKey = "__leanplum_identity_keys"
         
-        static let MigrateStateResponseParam = "migrateState"
-        static let SdkResponseParam = "sdk"
-        static let CTResponseParam = "ct"
-        static let AccountIdResponseParam = "accountId"
-        static let AccountTokenResponseParam = "token"
-        static let RegionCodeResponseParam = "regionCode"
-        static let AttributeMappingsResponseParam = "attributeMappings"
-        static let HashResponseParam = "sha256";
+        static let DefaultIdentityKeys = [IdentityManager.Constants.Identity]
         
         static let CleverTapRequestArg = "ct"
     }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 13.07.22.
-//  Copyright © 2022 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 
@@ -32,6 +32,9 @@ import Foundation
     
     @PropUserDefaults(key: Constants.AttributeMappingsKey, defaultValue: [:])
     var attributeMappings: [String: String]
+    
+    @PropUserDefaults(key: Constants.IdentityKeysKey, defaultValue: Constants.DefaultIdentityKeys)
+    var identityKeys: [String]
     
     @MigrationStateUserDefaults(key: Constants.MigrationStateKey, defaultValue: .undefined)
     var migrationState: MigrationState {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 9.07.22.
-//  Copyright © 2022 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 // Use @_implementationOnly to *not* expose CleverTapSDK to the Leanplum-Swift header
@@ -53,6 +53,7 @@ class CTWrapper: Wrapper {
     
     func launch() {
         let config = CleverTapInstanceConfig.init(accountId: accountId, accountToken: accountToken, accountRegion: accountRegion)
+        config.identityKeys = MigrationManager.shared.identityKeys
         config.useCustomCleverTapId = true
         config.logLevel = CleverTapLogLevel(LPLogManager.logLevel())
         cleverTapInstance = CleverTap.instance(with: config, andCleverTapID: identityManager.cleverTapID)

--- a/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
+++ b/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
@@ -139,6 +139,13 @@
 		6A9D0A9A273430A700466133 /* NotificationTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9D0A99273430A700466133 /* NotificationTestHelper.swift */; };
 		6A9DECA527B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
 		6A9DECA627B6ABFB00052807 /* change_host_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A9DECA427B69D8800052807 /* change_host_response.json */; };
+		6AA3505B29953CFF008677C1 /* get_migrate_state_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3505529953CEF008677C1 /* get_migrate_state_response.json */; };
+		6AA3505C29953D00008677C1 /* get_migrate_state_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3505529953CEF008677C1 /* get_migrate_state_response.json */; };
+		6AA3505E29955FD4008677C1 /* get_migrate_state_response_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3505D29955FD4008677C1 /* get_migrate_state_response_error.json */; };
+		6AA3505F29955FD4008677C1 /* get_migrate_state_response_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3505D29955FD4008677C1 /* get_migrate_state_response_error.json */; };
+		6AA3506129956040008677C1 /* get_migrate_state_response_missing.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3506029956040008677C1 /* get_migrate_state_response_missing.json */; };
+		6AA3506229956040008677C1 /* get_migrate_state_response_missing.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AA3506029956040008677C1 /* get_migrate_state_response_missing.json */; };
+		6AA3506429956AEC008677C1 /* MigrationResponsesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA3506329956AEC008677C1 /* MigrationResponsesTest.swift */; };
 		6AF543A228E883AD0025F2A9 /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF5439728E882CA0025F2A9 /* LeanplumLocationAndBeacons.framework */; };
 		6AF6426D298198160021A997 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; };
 		6AF6426E298198160021A997 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -355,6 +362,10 @@
 		6A9D0A99273430A700466133 /* NotificationTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestHelper.swift; sourceTree = "<group>"; };
 		6A9DECA427B69D8800052807 /* change_host_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = change_host_response.json; sourceTree = "<group>"; };
 		6AA13C742900546400EDCA69 /* LeanplumSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDK.xcodeproj; path = ../LeanplumSDK/LeanplumSDK.xcodeproj; sourceTree = "<group>"; };
+		6AA3505529953CEF008677C1 /* get_migrate_state_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = get_migrate_state_response.json; sourceTree = "<group>"; };
+		6AA3505D29955FD4008677C1 /* get_migrate_state_response_error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = get_migrate_state_response_error.json; sourceTree = "<group>"; };
+		6AA3506029956040008677C1 /* get_migrate_state_response_missing.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = get_migrate_state_response_missing.json; sourceTree = "<group>"; };
+		6AA3506329956AEC008677C1 /* MigrationResponsesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationResponsesTest.swift; sourceTree = "<group>"; };
 		6AEAEE592795B68700680F84 /* Leanplum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Leanplum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LeanplumLocationAndBeacons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AF5438D28E882CA0025F2A9 /* LeanplumSDKLocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDKLocation.xcodeproj; path = ../LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj; sourceTree = "<group>"; };
@@ -589,6 +600,9 @@
 				075AB1342684AB9D007CA1BD /* variants_response.json */,
 				075AB13A2684AB9D007CA1BD /* Malformed */,
 				6A9DECA427B69D8800052807 /* change_host_response.json */,
+				6AA3505529953CEF008677C1 /* get_migrate_state_response.json */,
+				6AA3505D29955FD4008677C1 /* get_migrate_state_response_error.json */,
+				6AA3506029956040008677C1 /* get_migrate_state_response_missing.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -658,6 +672,7 @@
 				6A37A8A928F0078500F4339F /* Migration+Extensions.swift */,
 				6A37A8AB28F00B5800F4339F /* IdentityManagerTest.swift */,
 				6A37A8AD28F0164700F4339F /* IdentityManagerMocks.swift */,
+				6AA3506329956AEC008677C1 /* MigrationResponsesTest.swift */,
 			);
 			path = Migration;
 			sourceTree = "<group>";
@@ -856,13 +871,16 @@
 				07828DB2268B4A630029A339 /* local_caps_week_response.json in Resources */,
 				07828DB5268B4A630029A339 /* local_caps_session_response.json in Resources */,
 				075AACF726847BF4007CA1BD /* LaunchScreen.storyboard in Resources */,
+				6AA3505E29955FD4008677C1 /* get_migrate_state_response_error.json in Resources */,
 				075AB1842684AB9D007CA1BD /* TiedPriorities2.json in Resources */,
 				07828DB4268B4A630029A339 /* local_caps_day_response.json in Resources */,
 				07828DB3268B4A630029A339 /* local_caps_response.json in Resources */,
 				075AB1862684AB9D007CA1BD /* TiedPrioritiesDifferentDelay.json in Resources */,
 				075AB15E2684AB9D007CA1BD /* action_response.json in Resources */,
 				075AB16C2684AB9D007CA1BD /* state_response.json in Resources */,
+				6AA3506129956040008677C1 /* get_migrate_state_response_missing.json in Resources */,
 				075AB0962684A1A4007CA1BD /* Leanplum-Info.plist in Resources */,
+				6AA3505B29953CFF008677C1 /* get_migrate_state_response.json in Resources */,
 				075AB1622684AB9D007CA1BD /* start_variables_response.json in Resources */,
 				075AB1702684AB9D007CA1BD /* batch_response.json in Resources */,
 				075AB1602684AB9D007CA1BD /* track_event_response.json in Resources */,
@@ -924,15 +942,18 @@
 				075AB1672684AB9D007CA1BD /* secured_vars_no_sign_response.json in Resources */,
 				075AB17F2684AB9D007CA1BD /* DifferentPriorities2.json in Resources */,
 				075AB1772684AB9D007CA1BD /* variables_response.json in Resources */,
+				6AA3506229956040008677C1 /* get_migrate_state_response_missing.json in Resources */,
 				075AB1572684AB9D007CA1BD /* test.pdf in Resources */,
 				075AB1792684AB9D007CA1BD /* secured_vars_response.json in Resources */,
 				075AB1892684AB9D007CA1BD /* TiedPriorities1.json in Resources */,
 				07828DAE268B4A5E0029A339 /* local_caps_day_response.json in Resources */,
 				075AB18B2684AB9D007CA1BD /* DifferentPrioritiesWithMissingValues.json in Resources */,
 				075AB1712684AB9D007CA1BD /* batch_response.json in Resources */,
+				6AA3505F29955FD4008677C1 /* get_migrate_state_response_error.json in Resources */,
 				075AB1692684AB9D007CA1BD /* malformed_track_event_response.json in Resources */,
 				075AB1592684AB9D007CA1BD /* test.file in Resources */,
 				075AB1872684AB9D007CA1BD /* TiedPrioritiesDifferentDelay.json in Resources */,
+				6AA3505C29953D00008677C1 /* get_migrate_state_response.json in Resources */,
 				075AB1652684AB9D007CA1BD /* start_with_variant_debug_info_response.json in Resources */,
 				075AB16F2684AB9D007CA1BD /* simple_start_response.json in Resources */,
 			);
@@ -1080,6 +1101,7 @@
 				075AB1172684AAD9007CA1BD /* LPRequestTest.m in Sources */,
 				6A9D0A9827342EE300466133 /* NotificationsManagerMock.swift in Sources */,
 				075AB1282684AAD9007CA1BD /* LPRequestFactory+Extension.m in Sources */,
+				6AA3506429956AEC008677C1 /* MigrationResponsesTest.swift in Sources */,
 				39C081A8278D95ED00C1DBD6 /* ActionManagerTest.swift in Sources */,
 				6A07FDA52811AF3800995BE3 /* ContentMergerTest.swift in Sources */,
 				075AB12A2684AAD9007CA1BD /* LPRequestSenderTimerTest.m in Sources */,

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
@@ -1,15 +1,15 @@
 //
-//  WrapperTest.swift
+//  CTWrapperTest.swift
 //  LeanplumSDKTests
 //
 //  Created by Nikola Zagorchev on 5.10.22.
-//
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 import XCTest
 @testable import Leanplum
 
-class WrapperTest: XCTestCase {
+class CTWrapperTest: XCTestCase {
     
     static let attributeMappings = ["lpName": "ctName", "lpName2": "ctName2"]
     let wrapper = CTWrapper(accountId: "", accountToken: "", accountRegion: "", userId: "", deviceId: "", callbacks: [])
@@ -117,5 +117,9 @@ class WrapperTest: XCTestCase {
         let expected = ["arr": "[a,1.99,b,2,true,false,0,<null>]"] as [AnyHashable : Any]
         XCTAssertTrue(actual.isEqual(expected))
         XCTAssertTrue(actualWithNil.isEqual(expected))
+    }
+    
+    func testIdentityDefaultValue() {
+        XCTAssertEqual(MigrationManager.shared.identityKeys, ["Identity"])
     }
 }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/MigrationResponsesTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/MigrationResponsesTest.swift
@@ -1,0 +1,84 @@
+//
+//  MigrationResponsesTest.swift
+//  LeanplumSDKTests
+//
+//  Created by Nikola Zagorchev on 9.02.23.
+//  Copyright © 2023 Leanplum. All rights reserved.
+
+import Foundation
+import XCTest
+@testable import Leanplum
+
+class MigrationResponsesTest: XCTestCase {
+    
+    struct Responses {
+        static let get_migrate_state_response = "get_migrate_state_response"
+        static let get_migrate_state_response_error = "get_migrate_state_response_error"
+        static let get_migrate_state_response_missing = "get_migrate_state_response_missing"
+        static let jsonType = "json"
+    }
+    
+    func testMigrationResponse() {
+        if let path = Bundle.main.path(forResource: Responses.get_migrate_state_response, ofType: Responses.jsonType) {
+            do {
+                let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+                let jsonResult = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+                let migrationData = MigrationManager.shared.parseResponse(apiResponse: jsonResult)
+                
+                let ctConfig = MigrationManager.CTConfig(accountID: "accId",
+                                                         token: "token",
+                                                         regionCode: "eu1",
+                                                         attributeMappings: ["name1": "ct-name1",],
+                                                         identityKeys: ["Identity", "Email"])
+                
+                let expectedData = MigrationManager.MigrationData(ct: ctConfig,
+                                                                  migrationState: "lp+ct",
+                                                                  hash: "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8")
+                
+                XCTAssertEqual(migrationData, expectedData)
+            } catch {
+                XCTFail(String(describing: error))
+            }
+        }
+    }
+    
+    func testMigrationResponseMissingKeys() {
+        if let path = Bundle.main.path(forResource: Responses.get_migrate_state_response_missing, ofType: Responses.jsonType) {
+            do {
+                let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+                let jsonResult = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+                let migrationData = MigrationManager.shared.parseResponse(apiResponse: jsonResult)
+                
+                let ctConfig = MigrationManager.CTConfig(accountID: nil,
+                                                         token: "token",
+                                                         regionCode: "eu1",
+                                                         attributeMappings: ["name1": "ct-name1",],
+                                                         identityKeys: nil)
+                
+                let expectedData = MigrationManager.MigrationData(ct: ctConfig,
+                                                                  migrationState: nil,
+                                                                  hash: nil)
+                
+                XCTAssertEqual(migrationData, expectedData)
+            } catch {
+                XCTFail(String(describing: error))
+            }
+        }
+    }
+    
+    func testMigrationResponseError() {
+        // The JSON has a type mismatch - individualKeys is of type String where expected type is String Array
+        if let path = Bundle.main.path(forResource: Responses.get_migrate_state_response_error, ofType: Responses.jsonType) {
+            do {
+                let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+                let jsonResult = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+                let migrationData = MigrationManager.shared.parseResponse(apiResponse: jsonResult)
+                
+                // If there is an error, the MigrationData will be nil
+                XCTAssertEqual(migrationData, nil)
+            } catch {
+                XCTFail(String(describing: error))
+            }
+        }
+    }
+}

--- a/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response.json
+++ b/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response.json
@@ -1,0 +1,22 @@
+{
+    "api": {
+        "events": "lp+ct",
+        "profile": "lp+ct",
+    },
+    "ct": {
+        "accountId": "accId",
+        "attributeMappings": {
+            "name1": "ct-name1",
+        },
+        "identityKeys": ["Identity", "Email"],
+        "regionCode": "eu1",
+        "token": "token",
+    },
+    "eventsUploadStartedTs": "2022-10-02T17:46:01.356Z",
+    "profileUploadStartedTs": "2022-10-02T17:46:01.356Z",
+    "reqId": "A285641F-9903-4182-8A10-EB42782CAE69",
+    "sdk": "lp+ct",
+    "sha256": "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8",
+    "state": "EVENTS_UPLOAD_STARTED",
+    "success": 1,
+}

--- a/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response_error.json
+++ b/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response_error.json
@@ -1,0 +1,22 @@
+{
+    "api": {
+        "events": "lp+ct",
+        "profile": "lp+ct",
+    },
+    "ct": {
+        "accountId": "accId",
+        "attributeMappings": {
+            "name1": "ct-name1",
+        },
+        "identityKeys": "",
+        "regionCode": "eu1",
+        "token": "token",
+    },
+    "eventsUploadStartedTs": "2022-10-02T17:46:01.356Z",
+    "profileUploadStartedTs": "2022-10-02T17:46:01.356Z",
+    "reqId": "A285641F-9903-4182-8A10-EB42782CAE69",
+    "sdk": "lp+ct",
+    "sha256": "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8",
+    "state": "EVENTS_UPLOAD_STARTED",
+    "success": 1,
+}

--- a/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response_missing.json
+++ b/LeanplumSDKApp/LeanplumSDKTests/Resources/Responses/get_migrate_state_response_missing.json
@@ -1,0 +1,14 @@
+{
+    "api": {
+        "events": "lp+ct",
+        "profile": "lp+ct",
+    },
+    "ct": {
+        "attributeMappings": {
+            "name1": "ct-name1",
+        },
+        "regionCode": "eu1",
+        "token": "token",
+    },
+    "success": 1,
+}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2684](https://wizrocket.atlassian.net/browse/SDK-2684)
People Involved   | @nzagorchev 

## Background
Identity keys are received through `getMigrateState` and set in the CleverTap configuration.
Example JSON:
```
{
    "ct" : {
        "accountId" : "accId",
        "attributeMappings" : ...,
        "identityKeys" : ["Identity", "Phone", "Email"]
    };
    ...
}
```
The default value is `"Identity"`.

If the keys are missing in the API response, or they are an empty array, they will not be updated. This means that previously saved or default keys will be used.
The keys that come from the API will not be further validated and will be passed directly as-is to the CT Config.

## Implementation
- Add the `identityKeys` to the `MigrationManager`
- Refactor the response handling to use `Codable`
- Add unit tests

## Testing steps

## Is this change backwards-compatible?
