### PR TITLE
Ensure swizzling in main thread

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -712,8 +712,6 @@ void leanplumExceptionHandler(NSException *exception);
          userAttributes:(NSDictionary *)attributes
         responseHandler:(LeanplumStartBlock)startResponse
 {
-    [[Leanplum notificationsManager].proxy setupNotificationSwizzling];
-    
     if ([ApiConfig shared].appId == nil) {
         [self throwError:@"Please provide your app ID using one of the [Leanplum setAppId:] "
          @"methods."];
@@ -727,6 +725,8 @@ void leanplumExceptionHandler(NSException *exception);
         });
         return;
     }
+    
+    [[Leanplum notificationsManager].proxy setupNotificationSwizzling];
     
     [LPFileManager clearCacheIfSDKUpdated];
     


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Move swizzling after the main thread check.
`UIApplication.delegate` must be used from the main thread.

## Implementation

## Testing steps

## Is this change backwards-compatible?
