### PR TITLE
Expose functionality for CleverTap push notifications

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -1622,6 +1622,24 @@ void leanplumExceptionHandler(NSException *exception);
     LP_END_TRY
 }
 
++ (void)setCleverTapOpenDeepLinksInForeground:(BOOL)openDeepLinksInForeground
+{
+    LPCTNotificationsManager *manager = (LPCTNotificationsManager *)[Leanplum notificationsManager];
+    [manager setOpenDeepLinksInForeground:openDeepLinksInForeground];
+}
+
++ (void)setHandleCleverTapNotification:(LeanplumHandleCleverTapNotificationBlock)block
+{
+    if (!block) {
+        [self throwError:@"[Leanplum setHandleCleverTapNotification:] Nil block parameter "
+         @"provided."];
+        return;
+    }
+    LP_TRY
+    ((LPCTNotificationsManager *)[Leanplum notificationsManager]).handleCleverTapNotificationBlock = block;
+    LP_END_TRY
+}
+
 + (void)setPushDeliveryTrackingEnabled:(BOOL)enabled
 {
     LP_TRY

--- a/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Leanplum.h
@@ -145,6 +145,9 @@ typedef void (^LeanplumSetLocationBlock)(BOOL success);
 typedef BOOL (^LeanplumActionBlock)(LPActionContext* context);
 typedef void (^LeanplumHandleNotificationBlock)(void);
 typedef void (^LeanplumShouldHandleNotificationBlock)(NSDictionary *userInfo, LeanplumHandleNotificationBlock response);
+typedef void (^LeanplumHandleCleverTapNotificationBlock)(NSDictionary *userInfo,
+                                                         BOOL isNotificationOpen,
+                                                         LeanplumHandleNotificationBlock response);
 typedef void (^LeanplumPushSetupBlock)(void);
 /**@}*/
 
@@ -435,6 +438,22 @@ NS_SWIFT_NAME(defineAction(name:kind:args:options:present:dismiss:));
  * Overrides the default behavior of showing an alert view with the notification message.
  */
 + (void)setShouldOpenNotificationHandler:(LeanplumShouldHandleNotificationBlock)block;
+
+/**
+ * CleverTap push notifications specific.
+ * Sets whether a notification's deeplink should be opened when push notification is recevied while the app is on the foreground.
+ * Default value is false.
+ */
++ (void)setCleverTapOpenDeepLinksInForeground:(BOOL)openDeepLinksInForeground;
+
+/**
+ * CleverTap push notifications specific.
+ * Block to call that decides how to handle a CleverTap push notification.
+ * received while the app is running, and the notification is not muted.
+ * The block provides the notification userInfo, a bool if the push is received or opened, and a block with the default implementation.
+ * @see LeanplumHandleCleverTapNotificationBlock for details.
+ */
++ (void)setHandleCleverTapNotification:(LeanplumHandleCleverTapNotificationBlock)block;
 
 /**
  * Sets if a Deliver event should be tracked when a Push Notification is received.


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2966](https://wizrocket.atlassian.net/browse/SDK-2966)
People Involved   | @nzagorchev 

## Background
Expose logic for CleverTap push notifications, so the behavior can be customized by clients using the Wrapper.

Changes default value for `openDeepLinksInForeground` to `false`.

## Implementation
Adds the following methods for better control over CleverTap push notifications:
- `setCleverTapOpenDeepLinksInForeground`
- `setHandleCleverTapNotification`

## Testing steps
Manual
## Is this change backwards-compatible?
Yes