### PR TITLE
CleverTap Push fixes

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Internal/Leanplum.m
@@ -3,7 +3,7 @@
 //  Leanplum
 //
 //  Created by Andrew First on 4/30/12.
-//  Copyright (c) 2022 Leanplum, Inc. All rights reserved.
+//  Copyright (c) 2023 Leanplum, Inc. All rights reserved.
 //
 //  Licensed to the Apache Software Foundation (ASF) under one
 //  or more contributor license agreements.  See the NOTICE file
@@ -1625,7 +1625,8 @@ void leanplumExceptionHandler(NSException *exception);
 + (void)setCleverTapOpenDeepLinksInForeground:(BOOL)openDeepLinksInForeground
 {
     LPCTNotificationsManager *manager = (LPCTNotificationsManager *)[Leanplum notificationsManager];
-    [manager setOpenDeepLinksInForeground:openDeepLinksInForeground];
+    NSNumber *value = [NSNumber numberWithBool:openDeepLinksInForeground];
+    [manager setOpenDeepLinksInForeground:value];
 }
 
 + (void)setHandleCleverTapNotification:(_Nullable LeanplumHandleCleverTapNotificationBlock)block

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
@@ -3,14 +3,15 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 12.10.22.
-//  Copyright © 2022 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 // Use @_implementationOnly to *not* expose CleverTapSDK to the Leanplum-Swift header
 @_implementationOnly import CleverTapSDK
 
 @objc public class LPCTNotificationsManager: NotificationsManager {
-    @objc public var openDeepLinksInForeground = false
+    // Using NSNumber since Optional Bool cannot be represented in Objective-C
+    @objc public var openDeepLinksInForeground: NSNumber?
     @objc public var handleCleverTapNotificationBlock: LeanplumHandleCleverTapNotificationBlock?
 
     
@@ -74,7 +75,8 @@ import Foundation
             return
         }
         
-        handleNotification(openDeepLinksInForeground)
+        // If `openDeepLinksInForeground` is not set explicitly, use `true` for notification Opens.
+        handleNotification(openDeepLinksInForeground?.boolValue ?? (event == .opened))
     }
     
     @objc public func handleWithCleverTapInstance(action: @escaping () -> ()) {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Notifications/Proxy/NotificationsProxy+Utilities.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Notifications/Proxy/NotificationsProxy+Utilities.swift
@@ -3,7 +3,7 @@
 //  LeanplumSDK
 //
 //  Created by Nikola Zagorchev on 23.12.21.
-//  Copyright © 2021 Leanplum. All rights reserved.
+//  Copyright © 2023 Leanplum. All rights reserved.
 
 import Foundation
 
@@ -13,7 +13,8 @@ extension NotificationsProxy {
         if let fromStart = notificationHandledFromStart {
             let idA = Leanplum.notificationsManager().getNotificationId(fromStart)
             let idB = Leanplum.notificationsManager().getNotificationId(userInfo)
-            return idA == idB
+            // CleverTap notifications do not have notification Id
+            return idA == idB && idA != "-1"
         }
         return false
     }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-3124](https://wizrocket.atlassian.net/browse/SDK-3124)
People Involved   | @nzagorchev 

## Background
- Fix `isEqualToHandledNotification` for CleverTap notifications.
If the app is launched from a CleverTap push notification, the consequent CleverTap notification opens will not work since `isEqualToHandledNotification` always returns `true` for CleverTap notifications - for notifications without notification Id (`lp_occurrence_id` key).

- Default CleverTap `openDeepLinksInForeground` to `true` when called from `notificationOpened`, unless `openDeepLinksInForeground` is explicitly set. Fixes an issue on Unity when the application is opened from a notification and the app takes a while to load. At that point, the notification open in CleverTap is executed when the app is in the foreground.

## Implementation
- Check if notifications have a notification Id set - the id should not be equal to the default one returned by the method `-1`.
- `openDeepLinksInForeground` is `nil` unless set explicitly. If not set, default to the notification event being Open or Receive. Use `openDeepLinksInForeground: true` if `Opened`.

## Testing steps

## Is this change backwards-compatible?
