### PR TITLE
Migration: Use loggedInUserId to identify previously logged-in users

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+Constants.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+Constants.swift
@@ -16,6 +16,7 @@ import Foundation
         static let RegionCodeKey = "__leanplum_region_code"
         static let AttributeMappingsKey = "__leanplum_attribute_mappings"
         static let IdentityKeysKey = "__leanplum_identity_keys"
+        static let LoggedInUserIdKey = "__leanplum_logged_in_user_id"
         
         static let DefaultIdentityKeys = [IdentityManager.Constants.Identity]
         

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
@@ -82,6 +82,7 @@ import Foundation
     //            "sdk": "lp+ct",
     //            "sha256": "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8",
     //            "state": "EVENTS_UPLOAD_STARTED",
+    //            "loggedInUserId": "9da5cdc6-m340-42a8-9110-1d4a1099f157",
     //            "success": 1,
     //        }
     //    ]

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
@@ -116,7 +116,9 @@ import Foundation
         if let loggedInUser = migrationData.loggedInUserId {
             loggedInUserId = loggedInUser
             Leanplum.onStartResponse { _ in
-                Leanplum.setUserId(loggedInUser)
+                if Leanplum.userId() == Leanplum.deviceId() {
+                    Leanplum.setUserId(loggedInUser)
+                }
             }
         }
         

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
@@ -115,7 +115,7 @@ import Foundation
         
         if let loggedInUser = migrationData.loggedInUserId {
             loggedInUserId = loggedInUser
-            Leanplum.onStartIssued {
+            Leanplum.onStartResponse { _ in
                 Leanplum.setUserId(loggedInUser)
             }
         }

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+ResponseHandler.swift
@@ -20,11 +20,13 @@ import Foundation
         let ct: CTConfig?
         let migrationState: String?
         let hash: String?
+        let loggedInUserId: String?
         
         enum CodingKeys: String, CodingKey {
             case hash = "sha256"
             case migrationState = "sdk"
             case ct
+            case loggedInUserId
         }
     }
 
@@ -106,11 +108,20 @@ import Foundation
             }
         }
         
-        if let sdk = migrationData.migrationState {
-            migrationState = MigrationState(stringValue: sdk)
-        }
         if let hash = migrationData.hash {
             migrationHash = hash
+        }
+        
+        if let loggedInUser = migrationData.loggedInUserId {
+            loggedInUserId = loggedInUser
+            Leanplum.onStartIssued {
+                Leanplum.setUserId(loggedInUser)
+            }
+        }
+        
+        // Changing the migrationState value will initialize the Wrapper
+        if let sdk = migrationData.migrationState {
+            migrationState = MigrationState(stringValue: sdk)
         }
     }
     

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager.swift
@@ -36,6 +36,9 @@ import Foundation
     @PropUserDefaults(key: Constants.IdentityKeysKey, defaultValue: Constants.DefaultIdentityKeys)
     var identityKeys: [String]
     
+    @StringOptionalUserDefaults(key: Constants.LoggedInUserIdKey)
+    var loggedInUserId: String?
+    
     @MigrationStateUserDefaults(key: Constants.MigrationStateKey, defaultValue: .undefined)
     var migrationState: MigrationState {
         didSet {
@@ -61,10 +64,11 @@ import Foundation
                 Log.error("[Wrapper] Missing Leanplum userId and deviceId. Cannot initialize CleverTap.")
                 return
             }
-
+            
             wrapper = CTWrapper(accountId: id, accountToken: token,
                                 accountRegion: accountRegion,
-                                userId: user, deviceId: device,
+                                useCustomCleverTapId: state != .cleverTap,
+                                userId: user, deviceId: device, loggedInUserId: loggedInUserId,
                                 callbacks: instanceCallbacks)
             wrapper?.launch()
         }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/CTWrapperTest.swift
@@ -12,8 +12,8 @@ import XCTest
 class CTWrapperTest: XCTestCase {
     
     static let attributeMappings = ["lpName": "ctName", "lpName2": "ctName2"]
-    let wrapper = CTWrapper(accountId: "", accountToken: "", accountRegion: "", userId: "", deviceId: "", callbacks: [])
-    
+    let wrapper = CTWrapper(accountId: "", accountToken: "", accountRegion: "", useCustomCleverTapId: true,
+                            userId: "", deviceId: "", loggedInUserId: nil, callbacks: [])
     override class func setUp() {
         MigrationManager.shared.attributeMappings = attributeMappings
     }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerMocks.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerMocks.swift
@@ -51,11 +51,11 @@ class IdentityManagerMockStatic: IdentityManager {
         }
     }
     
-    init(userId: String, deviceId: String, anonymousLoginUserId: String?, state: String?) {
+    init(userId: String, deviceId: String, anonymousLoginUserId: String?, state: String?, loggedInUserId: String? = nil) {
         // Needs to be set before call to super.init
         IdentityManagerMockStatic._anonymousLoginUserId = anonymousLoginUserId
         IdentityManagerMockStatic._state = state
         
-        super.init(userId: userId, deviceId: deviceId)
+        super.init(userId: userId, deviceId: deviceId, loggedInUserId: loggedInUserId)
     }
 }

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -21,6 +21,8 @@ class IdentityManagerTest: XCTestCase {
     // c9430313f85740d3c62dd8bf8c8d275165e96f830e7b1e6ddf3a89ba17ee5cce
     let userId2_hash = "c9430313f8"
     
+    let deviceId_hash = "5e51fbb1d8"
+    
     let totalIdLengthLimit = 61
     let deviceIdHashLength = 50
     
@@ -60,6 +62,125 @@ class IdentityManagerTest: XCTestCase {
         XCTAssertEqual(identityManager.cleverTapID, deviceId)
     }
     
+    func testAnonymousAndLoggedInUser() {
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+    }
+    
+    func testUserAndLoggedInUser() {
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+    }
+    
+    func testLoggedInUserLoginBack() {
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId2)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+    }
+    
+    func testLoggedInUserLoginAgainUser() {
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId2)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+    }
+    
+    func testLoggedInUserUserIdAlreadySet() {
+        let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId2)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+    }
+    
+    func testLoggedInUserSetDeviceIdBackAsUserId() {
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(deviceId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        
+        identityManager.setUserId(userId2)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+    }
+    
     func testIdentified() {
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
@@ -88,6 +209,26 @@ class IdentityManagerTest: XCTestCase {
         XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
         XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
         XCTAssertEqual(identityManager.cleverTapID, deviceId)
+    }
+    
+    func testAnonymousLoginDeviceId() {
+        let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
+        
+        identityManager.setUserId(deviceId)
+        
+        // isAnonymous is true since userId=deviceId
+        XCTAssertTrue(identityManager.isAnonymous)
+        // state is identified
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, deviceId_hash)
+        XCTAssertEqual(identityManager.cleverTapID, deviceId)
+        
+        identityManager.setUserId(userId)
+        
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.anonymousLoginUserId, deviceId_hash)
+        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
     }
     
     func testAnonymousLoginNewUser() {

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/IdentityManagerTest.swift
@@ -26,6 +26,13 @@ class IdentityManagerTest: XCTestCase {
     let totalIdLengthLimit = 61
     let deviceIdHashLength = 50
     
+    func assertUserIdIdentified(_ identityManager: IdentityManager, _ userId_hash: String, _ anonymousLoginUserId: String? = nil) {
+        XCTAssertFalse(identityManager.isAnonymous)
+        XCTAssertEqual(identityManager.anonymousLoginUserId, anonymousLoginUserId)
+        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
+        XCTAssertEqual(identityManager.cleverTapID, "\(deviceId)_\(userId_hash)")
+    }
+    
     func testProfile() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId)
         
@@ -65,160 +72,104 @@ class IdentityManagerTest: XCTestCase {
     func testAnonymousAndLoggedInUser() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
     }
     
     func testUserAndLoggedInUser() {
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
     }
     
     func testLoggedInUserLoginBack() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
         
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
     }
     
     func testLoggedInUserLoginAgainUser() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
     }
     
     func testLoggedInUserUserIdAlreadySet() {
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
         
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
     }
     
     func testLoggedInUserSetDeviceIdAsUserId() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(deviceId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(deviceId_hash)")
+        assertUserIdIdentified(identityManager, deviceId_hash)
 
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
     }
     
     func testLoggedInUserDeviceId() {
         let identityManager = IdentityManagerMock(userId: deviceId, deviceId: deviceId, loggedInUserId: deviceId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(deviceId_hash)")
+        assertUserIdIdentified(identityManager, deviceId_hash)
         
         // Set again the deviceId as userId
         identityManager.setUserId(deviceId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(deviceId_hash)")
+        assertUserIdIdentified(identityManager, deviceId_hash)
 
         // Set a new user Id
         identityManager.setUserId(userId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
         
         // Set another new user Id
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
     }
     
     func testIdentified() {
         let identityManager = IdentityManagerMock(userId: userId, deviceId: deviceId)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId_hash)")
+        assertUserIdIdentified(identityManager, userId_hash)
     }
     
     func testIdentifiedNewUser() {
@@ -226,10 +177,7 @@ class IdentityManagerTest: XCTestCase {
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, nil)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash)
     }
     
     func testAnonymousLogin() {
@@ -280,10 +228,7 @@ class IdentityManagerTest: XCTestCase {
         
         // Login with deviceId. Since is not anonymous, create a new profile
         identityManager.setUserId(deviceId)
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(deviceId_hash)")
+        assertUserIdIdentified(identityManager, deviceId_hash, userId_hash)
     }
     
     func testAnonymousLoginNewUser() {
@@ -293,10 +238,7 @@ class IdentityManagerTest: XCTestCase {
         
         identityManager.setUserId(userId2)
         
-        XCTAssertFalse(identityManager.isAnonymous)
-        XCTAssertEqual(identityManager.state, IdentityManager.IdentityState.identified())
-        XCTAssertEqual(identityManager.anonymousLoginUserId, userId_hash)
-        XCTAssertEqual(identityManager.cleverTapID, "deviceId_\(userId2_hash)")
+        assertUserIdIdentified(identityManager, userId2_hash, userId_hash)
     }
     
     func testAnonymousLoginBack() {

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/MigrationResponsesTest.swift
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Migration/MigrationResponsesTest.swift
@@ -33,7 +33,8 @@ class MigrationResponsesTest: XCTestCase {
                 
                 let expectedData = MigrationManager.MigrationData(ct: ctConfig,
                                                                   migrationState: "lp+ct",
-                                                                  hash: "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8")
+                                                                  hash: "31484a565dcd3e1672922c7c4166bfeee0f500b6d6473fc412091304cc162ca8",
+                                                                  loggedInUserId: nil)
                 
                 XCTAssertEqual(migrationData, expectedData)
             } catch {
@@ -57,7 +58,8 @@ class MigrationResponsesTest: XCTestCase {
                 
                 let expectedData = MigrationManager.MigrationData(ct: ctConfig,
                                                                   migrationState: nil,
-                                                                  hash: nil)
+                                                                  hash: nil,
+                                                                  loggedInUserId: nil)
                 
                 XCTAssertEqual(migrationData, expectedData)
             } catch {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Use `loggedInUserId` to identify previously logged-in users and identify them on reinstall. Used for CleverTap Migration and CleverTap ID.

## Implementation

## Testing steps
- Manual
- IdentityManager unit tests
## Is this change backwards-compatible?
Yes