### PR TITLE
Fix for warning: "upload task should not contain a body"

### DIFF
--- a/LeanplumSDK/LeanplumSDK/Classes/Managers/Networking/LPNetworkOperation.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Managers/Networking/LPNetworkOperation.m
@@ -197,14 +197,14 @@
     };
 
     // Use Upload Task for file & data upload, Data Task for others
-    self.request.HTTPBody = [self bodyData];
     if (self.requestFiles.count || self.requestDatas.count) {
         self.task = [self.session uploadTaskWithRequest:self.request
-                                               fromData:nil
+                                               fromData:[self bodyData]
                                       completionHandler:^(NSData * data, NSURLResponse * response, NSError * error) {
             responseBlock(data, response, error);
         }];
     } else {
+        self.request.HTTPBody = [self bodyData];
         self.task = [self.session dataTaskWithRequest:self.request
                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             responseBlock(data, response, error);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Fix for Xcode 15 warning:
```
The request of a upload task should not contain a body or a body stream, use `upload(for:fromFile`, `upload(for:from`, or supply the body stream through the `urlSession(_:needNewBodyStreamForTask` delegate method.
```
Issue: https://github.com/Leanplum/Leanplum-iOS-SDK/issues/573

This is reproduced only in Dev mode if App Icons are uploaded.
## Implementation
Do not set the request body for upload requests. Set the data into the `fromData` parameter.
## Testing steps
Manual
## Is this change backwards-compatible?
Yes