### PR TITLE
DevServer connection fix - Improve sockets handshake response check

### DIFF
--- a/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
+++ b/LeanplumSDK/LeanplumSDK.xcodeproj/project.pbxproj
@@ -488,6 +488,10 @@
 		6AD978582774F3F000A7C6C6 /* NotificationsProxy+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD978562774F3F000A7C6C6 /* NotificationsProxy+Utilities.swift */; };
 		6ADC90C72807461F00CE42C7 /* Dictionary+ValueKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADC90C62807461F00CE42C7 /* Dictionary+ValueKeyPath.swift */; };
 		6ADC90C82807461F00CE42C7 /* Dictionary+ValueKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADC90C62807461F00CE42C7 /* Dictionary+ValueKeyPath.swift */; };
+		6B7B6E8C2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B7B6E8A2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B7B6E8D2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B7B6E8A2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B7B6E8E2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B6E8B2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m */; };
+		6B7B6E8F2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B6E8B2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m */; };
 		A0371C8C3E1D6D0AB924FF99 /* libPods-Leanplum-Static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 897B64EE76852A68ECECB184 /* libPods-Leanplum-Static.a */; };
 		C90C489D2707299D00E33F1F /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90C489C2707299D00E33F1F /* NotificationSettings.swift */; };
 		C90C489E2707299D00E33F1F /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90C489C2707299D00E33F1F /* NotificationSettings.swift */; };
@@ -829,6 +833,8 @@
 		6AD978532774F2F700A7C6C6 /* NotificationsProxy+iOS9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsProxy+iOS9.swift"; sourceTree = "<group>"; };
 		6AD978562774F3F000A7C6C6 /* NotificationsProxy+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsProxy+Utilities.swift"; sourceTree = "<group>"; };
 		6ADC90C62807461F00CE42C7 /* Dictionary+ValueKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+ValueKeyPath.swift"; sourceTree = "<group>"; };
+		6B7B6E8A2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Leanplum_WebSocket+Utils.h"; sourceTree = "<group>"; };
+		6B7B6E8B2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Leanplum_WebSocket+Utils.m"; sourceTree = "<group>"; };
 		6C2FB1913D58B5EF901363C9 /* Pods_Leanplum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Leanplum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		897B64EE76852A68ECECB184 /* libPods-Leanplum-Static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Leanplum-Static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B335B24E5DF5CE017C0BE58D /* Pods-Leanplum-Static.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Leanplum-Static.release.xcconfig"; path = "Target Support Files/Pods-Leanplum-Static/Pods-Leanplum-Static.release.xcconfig"; sourceTree = "<group>"; };
@@ -1106,6 +1112,8 @@
 				075AADA826847EC3007CA1BD /* Leanplum_WebSocket.h */,
 				075AADA926847EC3007CA1BD /* AsyncSocket */,
 				075AADAC26847EC3007CA1BD /* Leanplum_WebSocket.m */,
+				6B7B6E8A2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h */,
+				6B7B6E8B2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m */,
 			);
 			path = WebSocket;
 			sourceTree = "<group>";
@@ -1454,6 +1462,7 @@
 				075AAE5526847EC4007CA1BD /* LPMessageTemplateUtilities.h in Headers */,
 				075AAE4026847EC4007CA1BD /* LPPushAskToAskMessageTemplate.h in Headers */,
 				075AAEA526847EC4007CA1BD /* UIDevice+IdentifierAddition.h in Headers */,
+				6B7B6E8C2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h in Headers */,
 				075AAE3126847EC4007CA1BD /* LPOpenUrlMessageTemplate.h in Headers */,
 				075AADF926847EC4007CA1BD /* LeanplumSocket.h in Headers */,
 				075AAEAC26847EC4007CA1BD /* LPVar-Internal.h in Headers */,
@@ -1542,6 +1551,7 @@
 				6A714B0326F8B317004A34A9 /* LPMessageTemplateUtilities.h in Headers */,
 				6A714B0426F8B317004A34A9 /* LPPushAskToAskMessageTemplate.h in Headers */,
 				6A714B0526F8B317004A34A9 /* UIDevice+IdentifierAddition.h in Headers */,
+				6B7B6E8D2B6A7A5400820306 /* Leanplum_WebSocket+Utils.h in Headers */,
 				6A714B0626F8B317004A34A9 /* LPOpenUrlMessageTemplate.h in Headers */,
 				6A714B0726F8B317004A34A9 /* LeanplumSocket.h in Headers */,
 				6A714B0826F8B317004A34A9 /* LPVar-Internal.h in Headers */,
@@ -1896,6 +1906,7 @@
 				6A9DEC6E27ABD52D00052807 /* ActionManager+Processor.swift in Sources */,
 				075AAE9D26847EC4007CA1BD /* NSTimer+Blocks.m in Sources */,
 				075AAE2026847EC4007CA1BD /* LPLogManager.m in Sources */,
+				6B7B6E8E2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m in Sources */,
 				39C0819F2781D3D000C1DBD6 /* ActionManager+Queue.swift in Sources */,
 				6A29EAF528EF37090024880E /* IdentityManager.swift in Sources */,
 				075AAEB126847EC4007CA1BD /* LPSecuredVars.m in Sources */,
@@ -2026,6 +2037,7 @@
 				6A9DEC6F27ABD52D00052807 /* ActionManager+Processor.swift in Sources */,
 				6A714B8426F8B317004A34A9 /* LPAppIconManager.m in Sources */,
 				6A714B8526F8B317004A34A9 /* NSTimer+Blocks.m in Sources */,
+				6B7B6E8F2B6A7A5400820306 /* Leanplum_WebSocket+Utils.m in Sources */,
 				6A714B8626F8B317004A34A9 /* LPLogManager.m in Sources */,
 				6A29EAF628EF37090024880E /* IdentityManager.swift in Sources */,
 				6A714B8726F8B317004A34A9 /* LPSecuredVars.m in Sources */,

--- a/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.h
+++ b/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.h
@@ -1,0 +1,24 @@
+//
+//  Leanplum_WebSocket+Utils.h
+//  LeanplumSDK
+//
+//  Created by Nikola Zagorchev on 31.01.24.
+//  Copyright © 2024 Leanplum. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import "Leanplum_WebSocket.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Leanplum_WebSocket (Utils)
+
+/**
+ * Checks if the socket handshake response is successful.
+ * Validates the HTTP status code, Upgrade and Connection headers.
+ * @param response The handshake string response.
+ */
++ (BOOL)isHandshakeSuccessful:(NSString *)response;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.m
@@ -18,11 +18,6 @@ NSString* const kConnectionHeaderExpected = @"upgrade";
 @implementation Leanplum_WebSocket (Utils)
 
 + (BOOL)isHandshakeSuccessful:(NSString *)response {
-    // Legacy check
-    if ([response hasPrefix:@"HTTP/1.1 101 Web Socket Protocol Handshake\r\nUpgrade: WebSocket\r\nConnection: Upgrade\r\n"]) {
-        return YES;
-    }
-    
     /* 
      Check the status code and headers.
      Status code is the second value, after the protocol.

--- a/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket+Utils.m
@@ -1,0 +1,70 @@
+//
+//  Leanplum_WebSocket+Utils.m
+//  LeanplumSDK
+//
+//  Created by Nikola Zagorchev on 31.01.24.
+//  Copyright © 2024 Leanplum. All rights reserved.
+
+#import "Leanplum_WebSocket+Utils.h"
+#import "LPLogManager.h"
+
+NSString* const kUpgradeHeader = @"upgrade:";
+NSString* const kConnectionHeader = @"connection:";
+NSString* const kStatusCodeString = @"101";
+
+NSString* const kUpgradeHeaderExpected = @"websocket";
+NSString* const kConnectionHeaderExpected = @"upgrade";
+
+@implementation Leanplum_WebSocket (Utils)
+
++ (BOOL)isHandshakeSuccessful:(NSString *)response {
+    // Legacy check
+    if ([response hasPrefix:@"HTTP/1.1 101 Web Socket Protocol Handshake\r\nUpgrade: WebSocket\r\nConnection: Upgrade\r\n"]) {
+        return YES;
+    }
+    
+    /* 
+     Check the status code and headers.
+     Status code is the second value, after the protocol.
+     Headers are case insensitive.
+     Example reponse string (new lines can be \r\n or \n):
+    @"HTTP/1.1 101 Switching Protocols\r\n\
+    WebSocket-Origin: http://dev.leanplum.com\r\n\
+    WebSocket-Location: ws://dev.leanplum.com/socket.io/1/websocket/y12oUiE3teSTh4S5TeSt\r\n\
+    Date: Wed, 31 Jan 2024 15:27:15 GMT\r\n\
+    Via: 1.1 google\r\n\
+    Upgrade: websocket\r\n\
+    Connection: Upgrade";
+     */
+    
+    NSArray *lines = [response componentsSeparatedByString:@"\n"];
+    NSString *firstLine = [lines firstObject];
+    NSArray *firstLineComponents = [firstLine componentsSeparatedByString:@" "];
+    if ([firstLineComponents count] > 2) {
+        NSString *statusCode = firstLineComponents[1];
+        if ([statusCode isEqualToString:kStatusCodeString]) {
+            // Iterate through the lines to find Upgrade and Connection values
+            NSString *upgradeValue;
+            NSString *connectionValue;
+            for (NSString *line in lines) {
+                NSString *lineLowercase = [line lowercaseString];
+                if ([lineLowercase hasPrefix:kUpgradeHeader]) {
+                    upgradeValue = [line substringFromIndex:[kUpgradeHeader length]];
+                } else if ([lineLowercase hasPrefix:kConnectionHeader]) {
+                    connectionValue = [line substringFromIndex:[kConnectionHeader length]];
+                }
+            }
+            if ([[upgradeValue lowercaseString] containsString:kUpgradeHeaderExpected] &&
+                [[connectionValue lowercaseString] containsString:kConnectionHeaderExpected]) {
+                return YES;
+            }
+            LPLog(LPDebug, @"Invalid Upgrade and/or Connection headers. Upgrade: %@, Connection: %@.", upgradeValue, connectionValue);
+        } else {
+            LPLog(LPDebug, @"Invalid Status Code: %@, line: %@.", statusCode, [lines firstObject]);
+        }
+    }
+
+    return NO;
+}
+
+@end

--- a/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket.m
+++ b/LeanplumSDK/LeanplumSDK/Classes/Utilities/Vendor/WebSocket/Leanplum_WebSocket.m
@@ -27,7 +27,8 @@
 
 #import "Leanplum_WebSocket.h"
 #import "Leanplum_AsyncSocket.h"
-
+#import "Leanplum_WebSocket+Utils.h"
+#import "LPLogManager.h"
 
 NSString* const Leanplum_WebSocketErrorDomain = @"WebSocketErrorDomain";
 NSString* const Leanplum_WebSocketException = @"WebSocketException";
@@ -160,7 +161,8 @@ enum {
 -(void)onSocket:(Leanplum_AsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag {
     if (tag == WebSocketTagHandshake) {
         NSString* response = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
-        if ([response hasPrefix:@"HTTP/1.1 101 Web Socket Protocol Handshake\r\nUpgrade: WebSocket\r\nConnection: Upgrade\r\n"]) {
+        LPLog(LPDebug, @"Handshake response: %@", response);
+        if ([Leanplum_WebSocket isHandshakeSuccessful:response]) {
             connected = YES;
             [self _dispatchOpened];
 
@@ -174,6 +176,7 @@ enum {
         if (firstByte != 0x00) return; // Discard message
         NSString* message = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(1, [data length]-2)] encoding:NSUTF8StringEncoding];
 
+        LPLog(LPDebug, @"Socket message: %@", message);
         [self _dispatchMessageReceived:message];
         [self _readNextMessage];
     }

--- a/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
+++ b/LeanplumSDKApp/LeanplumSDKApp.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		6AF543A228E883AD0025F2A9 /* LeanplumLocationAndBeacons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF5439728E882CA0025F2A9 /* LeanplumLocationAndBeacons.framework */; };
 		6AF6426D298198160021A997 /* Leanplum.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; };
 		6AF6426E298198160021A997 /* Leanplum.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AA13C7B2900546400EDCA69 /* Leanplum.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6B7B6E912B6A962000820306 /* Leanplum_WebSocketTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B6E902B6A962000820306 /* Leanplum_WebSocketTest.m */; };
 		779F1FAA8AA2F3872AC876B2 /* Pods_LeanplumSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3C9DA445D159EC6FF97D42D /* Pods_LeanplumSDKTests.framework */; };
 		82DC3FE9A5761B14AF26B301 /* Pods_LeanplumSDKApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 916957E1B3EE91A34170B5C7 /* Pods_LeanplumSDKApp.framework */; };
 		C9D064B1275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */; };
@@ -369,6 +370,7 @@
 		6AEAEE592795B68700680F84 /* Leanplum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Leanplum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AEAEE612795B72A00680F84 /* LeanplumLocationAndBeacons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LeanplumLocationAndBeacons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6AF5438D28E882CA0025F2A9 /* LeanplumSDKLocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LeanplumSDKLocation.xcodeproj; path = ../LeanplumSDKLocation/LeanplumSDKLocation.xcodeproj; sourceTree = "<group>"; };
+		6B7B6E902B6A962000820306 /* Leanplum_WebSocketTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Leanplum_WebSocketTest.m; sourceTree = "<group>"; };
 		916957E1B3EE91A34170B5C7 /* Pods_LeanplumSDKApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LeanplumSDKApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6B7D6D71F9664181C09E727 /* Pods-LeanplumSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LeanplumSDKTests.release.xcconfig"; path = "Target Support Files/Pods-LeanplumSDKTests/Pods-LeanplumSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		C9D064B0275DFB4B00A7A5F9 /* LeanplumNotificationsManagerUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeanplumNotificationsManagerUtilsTest.swift; sourceTree = "<group>"; };
@@ -518,6 +520,7 @@
 				6A39C48D27283EE7000D5320 /* LeanplumSDKTests-Bridging-Header.h */,
 				6A07FDAF283544E300995BE3 /* DictionaryValueKeyPathTest.swift */,
 				6A8411BA2903080A009F0431 /* UtilitiesTest.swift */,
+				6B7B6E902B6A962000820306 /* Leanplum_WebSocketTest.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1060,6 +1063,7 @@
 				075AB1102684AAD9007CA1BD /* LPInboxTest.m in Sources */,
 				075AB1112684AAD9007CA1BD /* LPSecuredVarsTest.m in Sources */,
 				075AB1192684AAD9007CA1BD /* LPFeatureFlagManagerTest.m in Sources */,
+				6B7B6E912B6A962000820306 /* Leanplum_WebSocketTest.m in Sources */,
 				075AB1222684AAD9007CA1BD /* LPActionContextTest.m in Sources */,
 				07828DB7268B4AA00029A339 /* LPLocalCapsTest.m in Sources */,
 				075AB1232684AAD9007CA1BD /* LPFileManagerTest.m in Sources */,

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Leanplum_WebSocketTest.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Leanplum_WebSocketTest.m
@@ -1,0 +1,100 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import <Leanplum/Leanplum_WebSocket+Utils.h>
+#import <Leanplum/Leanplum.h>
+
+@interface Leanplum_WebSocketTest : XCTestCase
+
+@end
+
+@implementation Leanplum_WebSocketTest
+
+- (void)testIsHandshakeSuccessfulLegacyResponse
+{
+    NSString *response = @"HTTP/1.1 101 Web Socket Protocol Handshake\r\n\
+Upgrade: WebSocket\r\n\
+Connection: Upgrade\r\n";
+    XCTAssertTrue([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulResponse
+{
+    NSString *response = @"HTTP/1.1 101 Switching Protocols\r\n\
+WebSocket-Origin: http://dev.leanplum.com\r\n\
+WebSocket-Location: ws://dev.leanplum.com/socket.io/1/websocket/y12oUiE3teSTh4S5TeSt\r\n\
+Date: Wed, 31 Jan 2024 15:27:15 GMT\r\n\
+Via: 1.1 google\r\n\
+Upgrade: websocket\r\n\
+Connection: Upgrade";
+    XCTAssertTrue([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulResponseCaseInsensitive
+{
+    NSString *response = @"HTTP/1.1 101 Switching Protocols\r\n\
+Upgrade: WebSocket\r\n\
+Connection: upgrade";
+    XCTAssertTrue([Leanplum_WebSocket isHandshakeSuccessful:response]);
+    
+    response = @"HTTP/1.1 101 Switching Protocols\r\n\
+upgrade: websocket\r\n\
+connection: Upgrade";
+    XCTAssertTrue([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulInvalidStatusCode
+{
+    NSString *response = @"HTTP/1.1 100 Switching Protocols\r\n\
+Upgrade: websocket\r\n\
+Connection: Upgrade";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulInvalidHeaders
+{
+    NSString *response = @"HTTP/1.1 100 Switching Protocols\r\n\
+Upgrade: protocol/1\r\n\
+Connection: keep-alive";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+    
+    NSString *responseInvalidConnection = @"HTTP/1.1 101 Switching Protocols\r\n\
+Upgrade: websocket\r\n\
+Connection: keep-alive";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:responseInvalidConnection]);
+    
+    NSString *responseInvalidUpgrade = @"HTTP/1.1 101 Switching Protocols\r\n\
+Upgrade: protocol/1\r\n\
+Connection: Upgrade";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:responseInvalidUpgrade]);
+}
+
+- (void)testIsHandshakeSuccessfulMissingHeaders
+{
+    NSString *response = @"HTTP/1.1 100 Switching Protocols\r\n\
+WebSocket-Origin: http://dev.leanplum.com\r\n\
+WebSocket-Location: ws://dev.leanplum.com/socket.io/1/websocket/y12oUiE3teSTh4S5TeSt\r\n\
+Date: Wed, 31 Jan 2024 15:27:15 GMT\r\n\
+Via: 1.1 google";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulInvalidResponse
+{
+    NSString *response = @"HTTP/1.1";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+    
+    response = @"HTTP/1.1 101 Switching Protocols";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+    
+    response = @"HTTP/1.1 Switching Protocols\r\n\
+WebSocket-Origin: http://dev.leanplum.com\r\n";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+- (void)testIsHandshakeSuccessfulEmptyResponse
+{
+    NSString *response = @"";
+    XCTAssertFalse([Leanplum_WebSocket isHandshakeSuccessful:response]);
+}
+
+@end

--- a/LeanplumSDKApp/LeanplumSDKTests/Classes/Leanplum_WebSocketTest.m
+++ b/LeanplumSDKApp/LeanplumSDKTests/Classes/Leanplum_WebSocketTest.m
@@ -11,9 +11,7 @@
 
 - (void)testIsHandshakeSuccessfulLegacyResponse
 {
-    NSString *response = @"HTTP/1.1 101 Web Socket Protocol Handshake\r\n\
-Upgrade: WebSocket\r\n\
-Connection: Upgrade\r\n";
+    NSString *response = @"HTTP/1.1 101 Web Socket Protocol Handshake\r\nUpgrade: WebSocket\r\nConnection: Upgrade\r\n";
     XCTAssertTrue([Leanplum_WebSocket isHandshakeSuccessful:response]);
 }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
The socket connection to the DevServer started failing. The server error is `websocket connection invalid` which results in error `WebSocketErrorDomain error 2` in the SDK.
The errors are caused by changes/rewriting to the request headers and the response.

1. The server expects `Upgrade: WebSocket` but receives `Upgrade: websocket` (The SDK does send `Upgrade: WebSocket`). This is fixed on the server.
2. The SDK expects a specific response and headers (direct comparison) but receives:
```
HTTP/1.1 101 Switching Protocols
WebSocket-Origin: http://dev-staging.leanplum.com/
WebSocket-Location: ws://dev-staging.leanplum.com/socket.io/1/websocket/DDeRoYTza-zUWMyDHIio
Date: Wed, 24 Jan 2024 11:04:28 GMT
Via: 1.1 google
Upgrade: websocket
Connection: Upgrade
```

## Implementation
Change the check for successful handshake. Parse the response and validate the status code, Upgrade and Connection headers.

## Testing steps
Manual testing the dev server connection. Unit tests.

## Is this change backwards-compatible?
Yes