### PR TITLE
fix: use resource_bundles for privacy manifest

### DIFF
--- a/Leanplum-iOS-Location.podspec
+++ b/Leanplum-iOS-Location.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source = { :git => 'https://github.com/Leanplum/Leanplum-iOS-SDK.git', :tag => s.version.to_s}
   s.source_files = 'LeanplumSDKLocation/LeanplumSDKLocation/Classes/**/*'
-  s.resources = 'LeanplumSDKLocation/LeanplumSDKLocation/*.{cer,xcprivacy}'
+  s.resources = 'LeanplumSDKLocation/LeanplumSDKLocation/*.{cer}'
+  s.resource_bundles = {'LeanplumLocation' => ['LeanplumSDKLocation/LeanplumSDKLocation/*.{xcprivacy}']} 
   s.frameworks = 'CoreLocation'
   s.documentation_url = 'https://docs.leanplum.com/'
   s.dependency 'Leanplum-iOS-SDK', "~> 6.0"


### PR DESCRIPTION
This is done to avoid getting build issues with multiple commands trying to produce xcprivacy file in application bundle.

For a more detailed explanation see: https://github.com/google/promises/pull/226#discussion_r1447871477