### PR TITLE
Move xcprivacy to Location pods bundle

### DIFF
--- a/Leanplum-iOS-Location.podspec
+++ b/Leanplum-iOS-Location.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source = { :git => 'https://github.com/Leanplum/Leanplum-iOS-SDK.git', :tag => s.version.to_s}
   s.source_files = 'LeanplumSDKLocation/LeanplumSDKLocation/Classes/**/*'
-  s.resources = 'LeanplumSDKLocation/LeanplumSDKLocation/*.{cer,xcprivacy}'
+  s.resource_bundles = {'LeanplumLocation' => ['LeanplumSDKLocation/LeanplumSDKLocation/*.{xcprivacy}']}
   s.frameworks = 'CoreLocation'
   s.documentation_url = 'https://docs.leanplum.com/'
   s.dependency 'Leanplum-iOS-SDK', "~> 6.0"

--- a/Leanplum-iOS-LocationAndBeacons.podspec
+++ b/Leanplum-iOS-LocationAndBeacons.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source = { :git => 'https://github.com/Leanplum/Leanplum-iOS-SDK.git', :tag => s.version.to_s}
   s.source_files = 'LeanplumSDKLocation/LeanplumSDKLocation/Classes/**/*'
-  s.resources = 'LeanplumSDKLocation/LeanplumSDKLocation/*.{cer,xcprivacy}'
+  s.resource_bundles = {'LeanplumLocation' => ['LeanplumSDKLocation/LeanplumSDKLocation/*.{xcprivacy}']}
   s.frameworks = 'CoreLocation'
   s.documentation_url = 'https://docs.leanplum.com/'
   s.dependency 'Leanplum-iOS-SDK', "~> 6.0"


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Move the xcprivacy file into resource bundle for Cocoapods. This prevents the error "multiple commands trying to produce xcprivacy file" when static linking is used.

## Implementation

## Testing steps

## Is this change backwards-compatible?
