### PR TITLE
Update CleverTap SDK version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "LeanplumLocation", targets: ["LeanplumLocation"])
     ],
     dependencies: [
-        .package(url: "https://github.com/CleverTap/clevertap-ios-sdk", from: "6.2.0")
+        .package(url: "https://github.com/CleverTap/clevertap-ios-sdk", from: "6.2.1")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @nzagorchev 

## Background
Update CleverTap SDK version. 
Update the version in SPM. 
CocoaPods uses 6.2 dependency which will automatically install 6.2.1.

## Implementation

## Testing steps

## Is this change backwards-compatible?
