### PR TITLE
Fixes push notification handled twice when app is using AppDelegate only.

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
@@ -13,7 +13,7 @@ import Foundation
     // Using NSNumber since Optional Bool cannot be represented in Objective-C
     @objc public var openDeepLinksInForeground: NSNumber?
     @objc public var handleCleverTapNotificationBlock: LeanplumHandleCleverTapNotificationBlock?
-
+    private(set) var handlePushNotificationFromCleverTap = false
     
     enum NotificationEvent: String, CustomStringConvertible {
         case opened = "Open"
@@ -33,6 +33,16 @@ import Foundation
         // If the app is launched from notification and CT instance has already been created,
         // CT will handle the notification from their UIApplication didFinishLaunchingNotification observer
         if fromLaunch && MigrationManager.shared.hasLaunched {
+            // If the app is using AppDelegate only, push notification at app launched will
+            // be handled from CleverTap. Setting `handlePushNotificationFromCleverTap` to true
+            // here ensures that app is launched from killed state and using AppDelegate file only.
+            handlePushNotificationFromCleverTap = true
+            return
+        }
+        
+        if handlePushNotificationFromCleverTap && MigrationManager.shared.hasLaunched {
+            Log.info("[Wrapper] Push Notification will be handled from CleverTap: \(userInfo)")
+            handlePushNotificationFromCleverTap = false
             return
         }
         


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [JIRA_TICKET_ID](https://wizrocket.atlassian.net/browse/MC-1886)
People Involved   | @nzagorchev

## Background
- When app is opened from killed state with push notification and app is using AppDelegate file only, push notification is handled twice - one from Leanplum wrapper side and one from CleverTap side. 
- When app is using SceneDelegate along with AppDelegate file, push is handled once as expected from Leanplum wrapper side. The main reason for this is after iOS v13.0 the `launchOptions` in `didFinishLaunchingWithOptions` method will be nil while using SceneDelegate, so CleverTap doesn't handle push notification for this case. 

## Implementation
- Added boolean `handlePushNotificationFromCleverTap` which will be set true only when app is launched from killed state using push notification and using AppDelegate file only. This boolean ensures push from killed state will be handled from CleverTap side only.

## Testing steps
We need to test the change for following cases and observe `Firing deep link` logs only once -
- Sending push from CleverTap for killed, background and foreground state with SceneDelegate and AppDelegate.
- Sending push from CleverTap for killed, background and foreground state without SceneDelegate.
- Sending push from Leanplum for killed, background and foreground state with SceneDelegate and AppDelegate.
- Sending push from Leanplum for killed, background and foreground state without SceneDelegate.

## Is this change backwards-compatible?
Yes
