### PR TITLE
Remove event property info from CT Wrapper

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/MigrationManager+API.swift
@@ -47,7 +47,7 @@
     }
 
     func track(_ eventName: String?, value: Double, info: String?, params: [String: Any]) {
-        wrapper?.track(eventName, value: value, info: info, params: params)
+        wrapper?.track(eventName, value: value, params: params)
     }
 
     func trackPurchase(_ eventName: String?, value: Double, currencyCode: String?, params: [String: Any]) {
@@ -71,7 +71,7 @@
     }
 
     func advance(_ eventName: String?, info: String?, params: [String: Any]) {
-        wrapper?.advance(eventName, info: info, params: params)
+        wrapper?.advance(eventName, params: params)
     }
 
     func setUserAttributes(_ attributes: [AnyHashable: Any]) {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/CTWrapper.swift
@@ -15,7 +15,6 @@ class CTWrapper: Wrapper {
         static let StatePrefix = "state_"
         
         static let ValueParamName = "value"
-        static let InfoParamName = "info"
         static let ChargedEventParam = "event"
         static let CurrencyCodeParam = "currencyCode"
         static let iOSTransactionIdentifierParam = "iOSTransactionIdentifier"
@@ -125,7 +124,7 @@ class CTWrapper: Wrapper {
     }
 
     // MARK: Tracking
-    func track(_ eventName: String?, value: Double, info: String?, params: [String: Any]) {
+    func track(_ eventName: String?, value: Double, params: [String: Any]) {
         // message impression events come with event: nil
         // do not track Push Delivered in CT
         guard let eventName = eventName, eventName != PUSH_DELIVERED_EVENT_NAME else {
@@ -134,23 +133,19 @@ class CTWrapper: Wrapper {
     
         var eventParams = params.mapValues(transformArrayValues)
         eventParams[Constants.ValueParamName] = value
-        
-        if let info = info {
-            eventParams[Constants.InfoParamName] = info
-        }
 
         Log.debug("Leanplum.track will call recordEvent with \(eventName) and \(eventParams)")
         cleverTapInstance?.recordEvent(eventName, withProps: eventParams)
     }
     
-    func advance(_ stateName: String?, info: String?, params: [String: Any]) {
+    func advance(_ stateName: String?, params: [String: Any]) {
         guard let stateName = stateName else {
             return
         }
         
         let eventName = Constants.StatePrefix + stateName
         Log.debug("Leanplum.advance will call track with \(eventName) and \(params)")
-        track(eventName, value: 0.0, info: info, params: params)
+        track(eventName, value: 0.0, params: params)
     }
     
     func trackPurchase(_ eventName: String?, value: Double, currencyCode: String?, params: [String: Any]) {

--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/Wrapper.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/Wrapper/Wrapper.swift
@@ -17,11 +17,11 @@ protocol Wrapper {
     
     func removeInstanceCallback(_ callback: CleverTapInstanceCallback)
     
-    func track(_ eventName: String?, value: Double, info: String?, params: [String: Any])
+    func track(_ eventName: String?, value: Double, params: [String: Any])
     
     func trackPurchase(_ eventName: String?, value: Double, currencyCode: String?, params: [String: Any])
     
-    func advance(_ stateName: String?, info: String?, params: [String: Any])
+    func advance(_ stateName: String?, params: [String: Any])
     
     func trackInAppPurchase(_ eventName: String?,
                             value: Double,


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [MC-2004](https://wizrocket.atlassian.net/browse/MC-2004)
People Involved   | @nzagorchev 

## Background
Remove the info parameter from events and states tracked in CleverTap through the Wrapper.

## Implementation

## Testing steps

## Is this change backwards-compatible?
