### PR TITLE
Revert "Fixes CT push notification handled twice"

### DIFF
--- a/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
+++ b/LeanplumSDK/LeanplumSDK/ClassesSwift/Migration/LPCTNotificationsManager.swift
@@ -13,7 +13,7 @@ import Foundation
     // Using NSNumber since Optional Bool cannot be represented in Objective-C
     @objc public var openDeepLinksInForeground: NSNumber?
     @objc public var handleCleverTapNotificationBlock: LeanplumHandleCleverTapNotificationBlock?
-    private(set) var handlePushNotificationFromCleverTap = false
+
     
     enum NotificationEvent: String, CustomStringConvertible {
         case opened = "Open"
@@ -33,16 +33,6 @@ import Foundation
         // If the app is launched from notification and CT instance has already been created,
         // CT will handle the notification from their UIApplication didFinishLaunchingNotification observer
         if fromLaunch && MigrationManager.shared.hasLaunched {
-            // If the app is using AppDelegate only, push notification at app launched will
-            // be handled from CleverTap. Setting `handlePushNotificationFromCleverTap` to true
-            // here ensures that app is launched from killed state and using AppDelegate file only.
-            handlePushNotificationFromCleverTap = true
-            return
-        }
-        
-        if handlePushNotificationFromCleverTap && MigrationManager.shared.hasLaunched {
-            Log.info("[Wrapper] Push Notification will be handled from CleverTap: \(userInfo)")
-            handlePushNotificationFromCleverTap = false
             return
         }
         


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [MC-1886](https://wizrocket.atlassian.net/browse/MC-1886)
People Involved   | @nzagorchev @nishant-clevertap 

## Background
Revert "Fixes CT push notification handled twice when app is using AppDelegate only. (#591)"

This reverts commit 04ebab0e81546b2abf39eb162521a6220f2855e1.

The change in the above commit leads to regression. If the app launch (didFinishLaunchingWithOptions) takes a bit more time (for example, on wrappers like ReactNative or Unity), the push notification open is not handled _at all_. The notification is not handled by Leanplum since it is left to CleverTap to handle it (the change in the commit). However, at that point, the application has become active and CleverTap does not handle the notification:
```
[CleverTap]: CleverTap.W84-WW7-756Z: app in foreground and openInForeground flag is FALSE, will not process any deep link for notification:
```

## Implementation
Revert the commit.

## Testing steps
Manual.

## Is this change backwards-compatible?
